### PR TITLE
feat: add newsbot CLI and config

### DIFF
--- a/newsbot/__init__.py
+++ b/newsbot/__init__.py
@@ -1,0 +1,6 @@
+"""Core package for newsbot."""
+
+__all__ = [
+    "config",
+    "bot",
+]

--- a/newsbot/bot.py
+++ b/newsbot/bot.py
@@ -1,0 +1,55 @@
+"""Minimal bot logic for newsbot.
+
+These functions are placeholders demonstrating how the CLI might
+interact with the rest of the system.
+"""
+
+import time
+from typing import Iterable, Dict
+
+from .config import KEYWORDS, SOURCES
+
+
+def fetch_from_sources(use_mock: bool = False) -> Iterable[Dict[str, str]]:
+    """Yield dummy items from configured sources."""
+    for src in SOURCES:
+        if use_mock:
+            title = f"Нижегородская область строительство news from {src}"
+        else:
+            title = f"Fetched news from {src}"
+        yield {"title": title, "url": src}
+
+
+def filter_items(items: Iterable[Dict[str, str]]) -> Iterable[Dict[str, str]]:
+    """Filter items that contain all keywords in their title."""
+    keywords = [k.lower() for k in KEYWORDS]
+    for item in items:
+        title = item["title"].lower()
+        if all(k in title for k in keywords):
+            yield item
+
+
+def publish_items(items: Iterable[Dict[str, str]], dry_run: bool = False) -> None:
+    """Publish items or print them in dry-run mode."""
+    for item in items:
+        if dry_run:
+            print(f"[DRY-RUN] Would publish: {item['title']}")
+        else:
+            print(f"Published: {item['title']}")
+
+
+def run_once(dry_run: bool = False, use_mock: bool = False) -> None:
+    """Run a single iteration of fetching, filtering and publishing."""
+    items = fetch_from_sources(use_mock=use_mock)
+    items = list(filter_items(items))
+    publish_items(items, dry_run=dry_run)
+
+
+def run_loop(dry_run: bool = False, use_mock: bool = False, interval: int = 60) -> None:
+    """Continuously run the bot with a delay between iterations."""
+    try:
+        while True:
+            run_once(dry_run=dry_run, use_mock=use_mock)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        print("Loop interrupted. Exiting...")

--- a/newsbot/config.py
+++ b/newsbot/config.py
@@ -1,0 +1,17 @@
+"""Configuration for newsbot.
+
+Contains keywords for filtering and a list of news sources.
+"""
+
+# Keywords for filtering news items
+KEYWORDS = [
+    "нижегородская область",
+    "строительство",
+]
+
+# RSS or HTML sources to poll for news
+SOURCES = [
+    "https://www.nn.ru/news/rss",
+    "https://www.vremyan.ru/rss",
+    "https://stroyportal.ru/news/rss",
+]

--- a/newsbot/main.py
+++ b/newsbot/main.py
@@ -1,0 +1,31 @@
+"""Command line interface for newsbot."""
+
+import argparse
+
+from . import bot
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create argument parser for the CLI."""
+    parser = argparse.ArgumentParser(description="Newsbot CLI")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--once", action="store_true", help="Run a single iteration")
+    mode.add_argument("--loop", action="store_true", help="Run continuously")
+    parser.add_argument("--dry-run", action="store_true", help="Do not publish messages")
+    parser.add_argument("--mock", action="store_true", help="Use mock data instead of fetching")
+    return parser
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.loop:
+        bot.run_loop(dry_run=args.dry_run, use_mock=args.mock)
+    else:
+        bot.run_once(dry_run=args.dry_run, use_mock=args.mock)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold `newsbot` package with placeholders
- implement CLI supporting once, loop, dry-run and mock flags
- configure keywords and sample news sources

## Testing
- `python -m newsbot.main --help`
- `python -m newsbot.main --once --dry-run --mock`
- `python -m newsbot.main --loop --dry-run --mock`
- `python -m py_compile newsbot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba9b247a288333ad73145712fb56f9