### PR TITLE
Implement Telegram publishing with dry run support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 feedparser==6.0.11
 requests==2.32.3
 beautifulsoup4==4.12.3
+python-telegram-bot==20.7


### PR DESCRIPTION
## Summary
- add python-telegram-bot dependency
- send news items to Telegram channel using BOT_TOKEN and CHANNEL_ID
- support dry-run mode and report send errors

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile newsbot/bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9dfc8a208333a4fa2e3c455c59f2