### PR TITLE
refactor: split keywords and structure sources

### DIFF
--- a/newsbot/bot.py
+++ b/newsbot/bot.py
@@ -40,19 +40,20 @@ def fetch_from_sources(use_mock: bool = False, limit: int = 10) -> Iterable[Dict
     """
 
     for src in SOURCES:
+        url = src["url"]
         if use_mock:
             yield {
-                "title": f"Нижегородская область строительство news from {src}",
-                "url": src,
-                "guid": src,
+                "title": f"Нижегородская область строительство news from {src['name']}",
+                "url": url,
+                "guid": url,
             }
             continue
 
         try:
-            response = requests.get(src, timeout=10)
+            response = requests.get(url, timeout=10)
             response.raise_for_status()
         except requests.RequestException as exc:
-            print(f"Error fetching {src}: {exc}")
+            print(f"Error fetching {src['name']}: {exc}")
             continue
 
         feed = feedparser.parse(response.content)
@@ -61,7 +62,7 @@ def fetch_from_sources(use_mock: bool = False, limit: int = 10) -> Iterable[Dict
         if entries:
             for entry in entries[:limit]:
                 title = entry.get("title", "").strip()
-                link = entry.get("link", src).strip()
+                link = entry.get("link", url).strip()
                 guid = entry.get("id") or entry.get("guid") or link
                 yield {"title": title, "url": link, "guid": guid}
             continue
@@ -72,7 +73,7 @@ def fetch_from_sources(use_mock: bool = False, limit: int = 10) -> Iterable[Dict
             title = tag.get_text(strip=True)
             if not title:
                 continue
-            link = urljoin(src, tag["href"])
+            link = urljoin(url, tag["href"])
             yield {"title": title, "url": link, "guid": link}
 
 

--- a/newsbot/config.py
+++ b/newsbot/config.py
@@ -4,14 +4,35 @@ Contains keywords for filtering and a list of news sources.
 """
 
 # Keywords for filtering news items
-KEYWORDS = [
+REGION_KEYWORDS = [
     "нижегородская область",
+]
+
+CONSTRUCTION_KEYWORDS = [
     "строительство",
 ]
 
+# Combined list used by the bot for filtering
+KEYWORDS = REGION_KEYWORDS + CONSTRUCTION_KEYWORDS
+
 # RSS or HTML sources to poll for news
 SOURCES = [
-    "https://www.nn.ru/news/rss",
-    "https://www.vremyan.ru/rss",
-    "https://stroyportal.ru/news/rss",
+    {
+        "name": "NN.ru",
+        "type": "rss",
+        "url": "https://www.nn.ru/news/rss",
+        "selectors": {},
+    },
+    {
+        "name": "Vremyan.ru",
+        "type": "rss",
+        "url": "https://www.vremyan.ru/rss",
+        "selectors": {},
+    },
+    {
+        "name": "StroyPortal",
+        "type": "rss",
+        "url": "https://stroyportal.ru/news/rss",
+        "selectors": {},
+    },
 ]


### PR DESCRIPTION
## Summary
- Split keywords into REGION_KEYWORDS and CONSTRUCTION_KEYWORDS and combine them for filtering
- Replace URL list with structured source dictionaries
- Update fetching logic to work with structured sources

## Testing
- `python -m newsbot.main --once --dry-run --mock`


------
https://chatgpt.com/codex/tasks/task_e_68baa10440088333a7621a2438afbd5b