### PR TITLE
Return detailed relevance info

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ def run_once(conn) -> Tuple[int, int, int, int, int, int, int, int]:
             title = normalize_whitespace(it.get("title") or "")
             content = normalize_whitespace(it.get("content") or "")
 
-            ok, region_ok, topic_ok, reason = filters.is_relevant_for_source(src, title, content)
+            ok, region_ok, topic_ok, reason = filters.is_relevant_for_source(title, content, src, config)
             if not ok:
                 logger.info("[SKIP] %s | %s | причина: %s", src, title, reason)
                 continue


### PR DESCRIPTION
## Summary
- expand filters.is_relevant and filters.is_relevant_for_source to return detailed relevance info and reasons
- update main to call filters.is_relevant_for_source(title, content, src, config)

## Testing
- `pytest`
- `python -m py_compile filters.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68baa43c577c83338f6b101458f7c692