### PR TITLE
Fix dedup remember call

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ def run_once(conn) -> Tuple[int, int, int, int, int, int, int, int]:
                 cnt_not_sent += 1
 
             # запоминаем в БД
-            dedup.remember(it, conn)
+            dedup.remember(conn, it)
 
         except KeyboardInterrupt:
             raise


### PR DESCRIPTION
## Summary
- fix argument order for `dedup.remember`

## Testing
- `python -m py_compile main.py dedup.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baa446bb608333bf5385ff028a8dd4