### PR TITLE
Add publish wrapper and ensure logging import

### DIFF
--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
+import logging  # стандартный модуль логирования
 import sys
 from . import config
 

--- a/publisher.py
+++ b/publisher.py
@@ -203,6 +203,15 @@ def publish_message(chat_id: str, title: str, body: str, url: str, cfg=config) -
         return False
 
 
+def publish(item: Dict[str, Any], cfg=config) -> bool:
+    """Публикует новость, извлекая данные из словаря."""
+    chat_id = str(cfg.CHANNEL_ID or "")
+    title = item.get("title") or ""
+    body = item.get("content") or ""
+    url = item.get("url") or ""
+    return publish_message(chat_id, title, body, url, cfg=cfg)
+
+
 def send_moderation_preview(chat_id: str, mod_title: str, title: str, body: str, url: str, mod_id: int, cfg=config) -> Optional[str]:
     """
     Отправляет модератору предпросмотр новости + инлайн-кнопки.


### PR DESCRIPTION
## Summary
- expose a `publish` helper that forwards news items to `publish_message` for Telegram
- document the `logging` import in the logging setup module

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68baa457ec0c8333bcdfc7e1d15a147e