### PR TITLE
Allow direct script execution and add PowerShell guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,36 @@ python -m config init
 ## Запуск
 Разово:
 ```bash
-python -m newsbot.main --once
+python main.py
 ```
 Цикл:
 ```bash
-python -m newsbot.main --loop
+python main.py --loop
 ```
-DRY-RUN + мок-набор:
-```bash
-python -m newsbot.main --once --dry-run --mock
+
+## Запуск через PowerShell
+Полный пример для Windows:
+
+```powershell
+# клонирование и переход в каталог проекта
+git clone <URL_репозитория>
+cd WebWork
+
+# при желании создаём виртуальное окружение
+py -3 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+
+# установка зависимостей
+pip install -r requirements.txt
+
+# однократная инициализация конфигурации (.env создастся в профиле пользователя)
+python -m config init
+
+# запуск одного прохода
+python .\main.py
+
+# запуск в бесконечном цикле
+python .\main.py --loop
 ```
 
 ## Формат логов

--- a/bot_updates.py
+++ b/bot_updates.py
@@ -2,7 +2,10 @@ import logging
 import time
 from typing import Optional
 
-from . import config, http_client, moderator, publisher, db
+try:
+    from . import config, http_client, moderator, publisher, db
+except ImportError:  # pragma: no cover
+    import config, http_client, moderator, publisher, db  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/db.py
+++ b/db.py
@@ -4,7 +4,10 @@ import os
 import sqlite3
 from typing import Any, Dict, Optional
 
-from . import config
+try:
+    from . import config
+except ImportError:  # pragma: no cover
+    import config  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/dedup.py
+++ b/dedup.py
@@ -4,7 +4,10 @@ import logging
 import re
 from typing import Optional
 
-from . import db, utils, config
+try:
+    from . import db, utils, config
+except ImportError:  # pragma: no cover
+    import db, utils, config  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/fetcher.py
+++ b/fetcher.py
@@ -8,8 +8,12 @@ from urllib.parse import urljoin
 import feedparser
 from requests import Response
 
-from . import config, http_client
-from .utils import normalize_whitespace, shorten_url
+try:
+    from . import config, http_client
+    from .utils import normalize_whitespace, shorten_url
+except ImportError:  # pragma: no cover
+    import config, http_client  # type: ignore
+    from utils import normalize_whitespace, shorten_url  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/http_client.py
+++ b/http_client.py
@@ -2,7 +2,10 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from . import config
+try:
+    from . import config
+except ImportError:  # pragma: no cover
+    import config  # type: ignore
 
 _session = None
 

--- a/images.py
+++ b/images.py
@@ -15,7 +15,10 @@ except Exception:  # pragma: no cover
 
 import sqlite3
 from collections import Counter
-from . import config, db, http_client
+try:
+    from . import config, db, http_client
+except ImportError:  # pragma: no cover
+    import config, db, http_client  # type: ignore
 
 HTTP_SESSION = http_client.get_session()
 

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging  # стандартный модуль логирования
 import sys
-from . import config
+try:
+    from . import config
+except ImportError:  # pragma: no cover
+    import config  # type: ignore
 
 _FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
 

--- a/main.py
+++ b/main.py
@@ -6,16 +6,25 @@ import time
 import threading
 from typing import Dict, List, Tuple
 
-from . import config, logging_setup, fetcher, filters, dedup, db, rewrite, images
-from . import moderator as moderation, bot_updates
-from .utils import normalize_whitespace, compute_title_hash
+try:
+    from . import config, logging_setup, fetcher, filters, dedup, db, rewrite, images
+    from . import moderator as moderation, bot_updates
+    from .utils import normalize_whitespace, compute_title_hash
+    try:
+        from . import publisher  # type: ignore
+    except Exception:  # pragma: no cover
+        publisher = None  # type: ignore
+except ImportError:  # pragma: no cover
+    import config, logging_setup, fetcher, filters, dedup, db, rewrite, images  # type: ignore
+    import moderator as moderation  # type: ignore
+    import bot_updates  # type: ignore
+    from utils import normalize_whitespace, compute_title_hash  # type: ignore
+    try:
+        import publisher  # type: ignore
+    except Exception:  # pragma: no cover
+        publisher = None  # type: ignore
 
 logger = logging.getLogger(__name__)
-
-try:
-    from . import publisher  # type: ignore
-except Exception:  # pragma: no cover
-    publisher = None  # type: ignore
 
 
 def _publisher_init() -> None:

--- a/moderator.py
+++ b/moderator.py
@@ -3,7 +3,10 @@ import sqlite3
 import time
 from typing import Any, Dict, Optional
 
-from . import config, publisher, db
+try:
+    from . import config, publisher, db
+except ImportError:  # pragma: no cover
+    import config, publisher, db  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/publisher.py
+++ b/publisher.py
@@ -8,8 +8,12 @@ import sqlite3
 
 import requests
 
-from . import config, db, rewrite, http_client, images
-from .utils import shorten_url
+try:
+    from . import config, db, rewrite, http_client, images
+    from .utils import shorten_url
+except ImportError:  # pragma: no cover
+    import config, db, rewrite, http_client, images  # type: ignore
+    from utils import shorten_url  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/sources.py
+++ b/sources.py
@@ -1,5 +1,8 @@
 from typing import Iterable, Dict
-from . import config
+try:
+    from . import config
+except ImportError:  # pragma: no cover
+    import config  # type: ignore
 
 def iter_sources() -> Iterable[Dict[str, str]]:
     for s in config.SOURCES:


### PR DESCRIPTION
## Summary
- make internal imports robust to package or script execution
- document how to run the bot via Windows PowerShell

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be90de641c83339b0b3fc3be97a7ed