### PR TITLE
Validate Telegram chat IDs to prevent chat not found errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 # and fill in the required values.
 BOT_TOKEN=
 CHANNEL_ID=
+REVIEW_CHAT_ID=
+CHANNEL_CHAT_ID=
 ADMIN_CHAT_ID=
 
 # Optional settings

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ python -m config init
 - `IMAGE_ALLOWED_EXT`, `IMAGE_DENYLIST_DOMAINS`, `MIN_IMAGE_BYTES`
 - ключевые слова и источники в `newsbot/config.py`
 
+Переменные `CHANNEL_ID`/`CHANNEL_CHAT_ID` и `REVIEW_CHAT_ID` должны быть заполнены
+реальными идентификаторами каналов или чатов. Иначе попытка отправить сообщение
+в Telegram завершится ошибкой вида `Bad Request: chat not found`.
+
 В блоке `SOURCES` у каждого источника теперь есть флаг `enabled` и опциональные
 поля `timeout`/`retry` для индивидуальных сетевых настроек.
 

--- a/config.py
+++ b/config.py
@@ -103,10 +103,16 @@ LOOP_DELAY_SECS: int = int(os.getenv("LOOP_DELAY_SECS", "600"))
 
 
 def validate_config() -> None:
-    if not BOT_TOKEN:
+    invalid_token = {"", "YOUR_TELEGRAM_BOT_TOKEN"}
+    if BOT_TOKEN in invalid_token:
         raise ValueError("BOT_TOKEN is required")
-    if not (CHANNEL_ID or CHANNEL_CHAT_ID):
+    invalid_channel = {"", "@your_main_channel"}
+    if (CHANNEL_ID in invalid_channel) and (str(CHANNEL_CHAT_ID) in invalid_channel):
         raise ValueError("CHANNEL_CHAT_ID or CHANNEL_ID is required")
+    if ENABLE_MODERATION:
+        invalid_review = {"", "@your_review_channel"}
+        if str(REVIEW_CHAT_ID) in invalid_review:
+            raise ValueError("REVIEW_CHAT_ID is required when moderation is enabled")
     if not isinstance(MODERATOR_IDS, set) or not all(isinstance(x, int) for x in MODERATOR_IDS):
         raise ValueError("MODERATOR_IDS must be a set of ints")
 


### PR DESCRIPTION
## Summary
- require real Telegram chat IDs in config validation and throw a clear error when missing
- document required REVIEW_CHAT_ID/CHANNEL_CHAT_ID and include them in `.env.example`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb0e8f9988333a6a39836c2c9998e