### PR TITLE
feat: add image fallback selection

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ try:  # pragma: no cover - simple fallback handling
         ENABLE_MODERATION as DEFAULT_ENABLE_MODERATION,
         REVIEW_CHAT_ID as DEFAULT_REVIEW_CHAT_ID,
         MODERATOR_IDS as DEFAULT_MODERATOR_IDS,
+        FALLBACK_IMAGE_URL as DEFAULT_FALLBACK_IMAGE_URL,
     )
 except Exception:  # pragma: no cover - executed only when defaults missing
     DEFAULT_BOT_TOKEN = ""
@@ -35,6 +36,7 @@ except Exception:  # pragma: no cover - executed only when defaults missing
     DEFAULT_ENABLE_MODERATION = False
     DEFAULT_REVIEW_CHAT_ID = ""
     DEFAULT_MODERATOR_IDS: set[int] = set()
+    DEFAULT_FALLBACK_IMAGE_URL = "https://example.com/placeholder.png"
 
 # === Базовые настройки бота ===
 BOT_TOKEN: str = os.getenv("BOT_TOKEN", DEFAULT_BOT_TOKEN).strip()
@@ -72,6 +74,11 @@ IMAGE_DENYLIST_DOMAINS = set(
     for d in os.getenv("IMAGE_DENYLIST_DOMAINS", "mc.yandex.ru,top-fwz1.mail.ru,counter,logo,pixel").split(",")
     if d.strip()
 )
+
+FALLBACK_IMAGE_URL: str = os.getenv(
+    "FALLBACK_IMAGE_URL",
+    DEFAULT_FALLBACK_IMAGE_URL,
+).strip()
 
 LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
 

--- a/config_defaults.py
+++ b/config_defaults.py
@@ -14,3 +14,4 @@ CHANNEL_ID = "@your_main_channel"
 ENABLE_MODERATION = True
 REVIEW_CHAT_ID = "@your_review_channel"
 MODERATOR_IDS = {123456789}
+FALLBACK_IMAGE_URL = "https://example.com/placeholder.png"

--- a/main.py
+++ b/main.py
@@ -139,13 +139,12 @@ def run_once(conn) -> Tuple[int, int, int, int, int, int, int, int]:
 
             item_clean = rewrite.maybe_rewrite_item(item_clean, config)
 
-            candidates = images.extract_candidates(item_clean)
-            best = images.pick_best(candidates)
-            if best:
-                res = images.ensure_tg_file_id(best.url, conn)
+            best_url = images.select_image_with_fallback(item_clean)
+            if best_url:
+                res = images.ensure_tg_file_id(best_url, conn)
                 if res:
                     tg_file_id, ihash = res
-                    item_clean["image_url"] = best.url
+                    item_clean["image_url"] = best_url
                     item_clean["tg_file_id"] = tg_file_id
                     item_clean["image_hash"] = ihash
                 else:

--- a/tests/test_image_fallback.py
+++ b/tests/test_image_fallback.py
@@ -1,0 +1,22 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from WebWork import images, config
+
+
+def test_select_image_json_ld(monkeypatch):
+    item = {
+        "title": "t",
+        "content": '<script type="application/ld+json">{"image": "http://img/ld.png"}</script>'
+    }
+    url = images.select_image_with_fallback(item)
+    assert url == "http://img/ld.png"
+
+
+def test_select_image_fallback(monkeypatch):
+    monkeypatch.setattr(config, "FALLBACK_IMAGE_URL", "http://fallback/img.png")
+    item = {"title": "t", "content": "no images"}
+    url = images.select_image_with_fallback(item)
+    assert url == "http://fallback/img.png"
+


### PR DESCRIPTION
## Summary
- add configurable fallback image URL
- extract images from JSON-LD and select fallback when none found
- integrate fallback image lookup into publishing pipeline
- cover JSON-LD and fallback cases with tests
- combine inline and JSON-LD extraction into single candidate list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed201791c8333845f128b1fbae539