### PR TITLE
Add startup script for automatic setup and run

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# create and activate virtual environment
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+. .venv/bin/activate
+
+# install dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# initialize configuration if missing
+if [ ! -f "$HOME/NewsBot/.env" ] && [ -f ".env.example" ]; then
+  python -m config init || cp .env.example "$HOME/NewsBot/.env"
+fi
+
+# run the bot with any passed arguments
+python main.py "$@"
+
+cat <<'EOT'
+
+Запуск завершён.
+Дальнейшие команды:
+  python main.py             # запуск одного прохода
+  python main.py --loop      # запуск в бесконечном цикле
+EOT


### PR DESCRIPTION
## Summary
- Add `start.sh` script to install dependencies, initialize configuration, run the bot and display follow-up commands

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfb9ea05ac8333a2d69af24d03d0e7