### PR TITLE
Add startup script for automatic setup and run

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal
+
+rem create and activate virtual environment
+if not exist ".venv" (
+    python -m venv .venv
+)
+call .venv\Scripts\activate
+
+rem install dependencies
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+
+rem initialize configuration if missing
+set "ENV_PATH=%USERPROFILE%\NewsBot\.env"
+if not exist "%ENV_PATH%" (
+    if not exist "%USERPROFILE%\NewsBot" mkdir "%USERPROFILE%\NewsBot"
+    if exist ".env.example" (
+        python -m config init || copy ".env.example" "%ENV_PATH%"
+    )
+)
+
+rem run the bot with any passed arguments
+python main.py %*
+
+echo.
+echo Запуск завершён.
+echo Дальнейшие команды:
+echo   python main.py             # запуск одного прохода
+echo   python main.py --loop      # запуск в бесконечном цикле
+
+endlocal

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# create and activate virtual environment
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+. .venv/bin/activate
+
+# install dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# initialize configuration if missing
+if [ ! -f "$HOME/NewsBot/.env" ] && [ -f ".env.example" ]; then
+  python -m config init || cp .env.example "$HOME/NewsBot/.env"
+fi
+
+# run the bot with any passed arguments
+python main.py "$@"
+
+cat <<'EOT'
+
+Запуск завершён.
+Дальнейшие команды:
+  python main.py             # запуск одного прохода
+  python main.py --loop      # запуск в бесконечном цикле
+EOT


### PR DESCRIPTION
## Summary
- Add `start.sh` script to install dependencies, initialize configuration, run the bot and display follow-up commands
- Add `start.bat` to provide Windows-compatible startup script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfb9ea05ac8333a2d69af24d03d0e7