### PR TITLE
Fix image attachment handling and caching

### DIFF
--- a/config.py
+++ b/config.py
@@ -117,9 +117,13 @@ REVIEW_TTL_HOURS: int = int(os.getenv("REVIEW_TTL_HOURS", "24"))
 CAPTION_LIMIT: int = int(os.getenv("CAPTION_LIMIT", "1024"))
 TELEGRAM_MESSAGE_LIMIT: int = int(os.getenv("TELEGRAM_MESSAGE_LIMIT", "4096"))
 PREVIEW_MODE: str = os.getenv("PREVIEW_MODE", "auto")
-TELEGRAM_PARSE_MODE: str = os.getenv(
-    "PARSE_MODE", os.getenv("TELEGRAM_PARSE_MODE", "HTML")
-)
+_RAW_PARSE_MODE = os.getenv("PARSE_MODE", os.getenv("TELEGRAM_PARSE_MODE", "HTML"))
+if _RAW_PARSE_MODE.strip().lower() == "markdownv2":
+    TELEGRAM_PARSE_MODE: str = "MarkdownV2"
+elif _RAW_PARSE_MODE.strip().lower() == "html":
+    TELEGRAM_PARSE_MODE = "HTML"
+else:
+    TELEGRAM_PARSE_MODE = _RAW_PARSE_MODE.strip()
 TELEGRAM_DISABLE_WEB_PAGE_PREVIEW: bool = (
     os.getenv(
         "DISABLE_WEB_PAGE_PREVIEW",

--- a/formatting/telegram.py
+++ b/formatting/telegram.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import List
 
-_SPECIAL_CHARS = r"_*[]()~`>#+-=|{}.!"
+_SPECIAL_CHARS = r"_*[]()~`>#+-=|{}.!\\"
 _ESCAPE_RE = re.compile("([" + re.escape(_SPECIAL_CHARS) + "])" )
 
 
@@ -12,18 +12,29 @@ def escape_markdown_v2(text: str) -> str:
     return _ESCAPE_RE.sub(r"\\\\\1", text)
 
 
+def sanitize_markdown_v2(text: str) -> str:
+    """Remove trailing escape characters that could break MarkdownV2."""
+    while text and text[-1] in _SPECIAL_CHARS:
+        if len(text) >= 2 and text[-2] == "\\":
+            break
+        text = text[:-1]
+    if text.endswith("\\"):
+        text = text[:-1]
+    return text
+
+
 def split_to_telegram_chunks(text: str, limit: int = 4096) -> List[str]:
     """Split text into chunks not exceeding Telegram limit.
 
     Prefer breaking on sentence or newline boundaries; fall back to words.
     """
     if len(text) <= limit:
-        return [text]
+        return [sanitize_markdown_v2(text)]
     parts: List[str] = []
     rest = text
     while rest:
         if len(rest) <= limit:
-            parts.append(rest.strip())
+            parts.append(sanitize_markdown_v2(rest.strip()))
             break
         cut = rest.rfind("\n", 0, limit)
         if cut == -1:
@@ -32,6 +43,7 @@ def split_to_telegram_chunks(text: str, limit: int = 4096) -> List[str]:
                 cut = rest.rfind(" ", 0, limit)
                 if cut == -1:
                     cut = limit
-        parts.append(rest[:cut].strip())
+        part = rest[:cut].strip()
+        parts.append(sanitize_markdown_v2(part))
         rest = rest[cut:].lstrip()
     return [p for p in parts if p]

--- a/media/extractor.py
+++ b/media/extractor.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import re
 from html import unescape
 from typing import List
+from urllib.parse import urljoin
 
 from rewriter.base import NewsItem
 
 _META_RE = re.compile(r'<meta[^>]+?(?:property|name)="(?:og:image|twitter:image)"[^>]+?content="([^"]+)"', re.I)
-_IMG_RE = re.compile(r'<img[^>]+src=["\']([^"\']+)["\']', re.I)
+_IMG_RE = re.compile(
+    r'<img[^>]+(?:src|data-src|data-original)=["\']([^"\']+)["\']', re.I
+)
+_SRCSET_RE = re.compile(r'<(?:img|source)[^>]+srcset=["\']([^"\']+)["\']', re.I)
 
 
 def extract_image_urls(item: NewsItem) -> List[str]:
@@ -18,10 +22,19 @@ def extract_image_urls(item: NewsItem) -> List[str]:
         html = unescape(item.html)
         urls.extend(_META_RE.findall(html))
         urls.extend(_IMG_RE.findall(html))
+        for srcset in _SRCSET_RE.findall(html):
+            first = srcset.split(",")[0].strip().split(" ")[0]
+            if first:
+                urls.append(first)
     seen = set()
     out: List[str] = []
     for u in urls:
-        if u and u not in seen:
-            seen.add(u)
-            out.append(u)
+        if not u:
+            continue
+        if item.url:
+            u = urljoin(item.url, u)
+        if u in seen:
+            continue
+        seen.add(u)
+        out.append(u)
     return out

--- a/media/scorer.py
+++ b/media/scorer.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 from typing import List, Optional
+import re
 
 
-BAD_KEYWORDS = {"logo", "sprite", "icon", "advert"}
+BAD_KEYWORDS = {"logo", "sprite", "icon", "advert", "1x1", "pixel"}
 
 
 def score_url(url: str) -> int:
     low = url.lower()
+    score = 0
     if any(k in low for k in BAD_KEYWORDS):
-        return -10
-    return 0
+        score -= 10
+    if low.endswith(('.gif', '.webp')):
+        score -= 5
+    m = re.search(r'(\d+)x(\d+)', low)
+    if m and (m.group(1) == '1' or m.group(2) == '1'):
+        score -= 5
+    return score
 
 
 def pick_best(urls: List[str]) -> Optional[str]:

--- a/tests/test_formatting_telegram.py
+++ b/tests/test_formatting_telegram.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from formatting.telegram import escape_markdown_v2
+from formatting.telegram import escape_markdown_v2, sanitize_markdown_v2, split_to_telegram_chunks
 
 
 def test_escape_markdown_v2():
@@ -11,3 +11,12 @@ def test_escape_markdown_v2():
     esc = escape_markdown_v2(s)
     for ch in s:
         assert f"\\{ch}" in esc
+
+
+def test_markdownv2_truncation_is_safe():
+    text = "a" * 49 + "\\"
+    parts = split_to_telegram_chunks(text, limit=50)
+    assert parts[0] == "a" * 49
+    for part in parts:
+        assert not part.endswith("\\")
+        assert sanitize_markdown_v2(part) == part

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -24,7 +24,7 @@ class Resp:
         yield self.content
 
 
-def test_image_cache(monkeypatch):
+def test_no_fake_tg_file_id_generated(monkeypatch):
     calls = {"head": 0, "get": 0}
 
     def fake_head(url, timeout, allow_redirects=True):
@@ -56,6 +56,6 @@ def test_image_cache(monkeypatch):
 
     fid1, h1 = images.ensure_tg_file_id("http://e/img.png", conn)
     fid2, h2 = images.ensure_tg_file_id("http://e/img.png", conn)
-    assert fid1 == fid2
+    assert fid1 is None and fid2 is None
     assert h1 == h2
     assert calls["head"] == 1 and calls["get"] == 1

--- a/tests/test_image_fallback.py
+++ b/tests/test_image_fallback.py
@@ -14,7 +14,7 @@ def test_select_image_json_ld(monkeypatch):
     assert url == "http://img/ld.png"
 
 
-def test_select_image_fallback(monkeypatch):
+def test_fallback_image_is_used_when_none_found(monkeypatch):
     monkeypatch.setattr(config, "FALLBACK_IMAGE_URL", "http://fallback/img.png")
     item = {"title": "t", "content": "no images"}
     url = images.select_image_with_fallback(item)
@@ -24,8 +24,8 @@ def test_select_image_fallback(monkeypatch):
 def test_resolve_image_uses_fallback_when_candidate_invalid(monkeypatch):
     monkeypatch.setattr(config, "FALLBACK_IMAGE_URL", "http://fallback/img.png")
 
-    # ensure_tg_file_id returns None for any URL to emulate validation failure
-    monkeypatch.setattr(images, "ensure_tg_file_id", lambda url, conn=None: None)
+    # probe_image returns None for any URL to emulate validation failure
+    monkeypatch.setattr(images, "probe_image", lambda url: None)
 
     item = {"title": "t", "content": '<img src="http://bad/img.png">'}
     info = images.resolve_image(item)

--- a/tests/test_publisher_modes.py
+++ b/tests/test_publisher_modes.py
@@ -3,10 +3,10 @@ import pathlib
 import sqlite3
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from WebWork import publisher, db, moderator, config, images
+from WebWork import publisher, db, moderator, config
 
 
-def test_publish_from_queue_fallback(monkeypatch):
+def test_publish_from_queue_prefers_url_then_caches_file_id(monkeypatch):
     conn = db.connect(":memory:")
     db.init_schema(conn)
     conn.execute(
@@ -22,24 +22,44 @@ def test_publish_from_queue_fallback(monkeypatch):
 
     def fake_send_photo(chat_id, photo, caption, parse_mode):
         called["photo"] = photo
-        return ("m1", None)
+        return ("m1", "fid1")
 
     def fake_send_text(chat_id, text, parse_mode):
         return "m2"
 
-    def fake_ensure(url, conn):
-        called["ensure"] = url
-        return ("fid1", "h1")
-
     monkeypatch.setattr(publisher, "_send_photo", fake_send_photo)
     monkeypatch.setattr(publisher, "_send_text", fake_send_text)
-    monkeypatch.setattr(images, "ensure_tg_file_id", fake_ensure)
 
     mid = publisher.publish_from_queue(conn, 1, cfg=config)
     assert mid == "m1"
-    assert called["photo"] == "fid1"
+    assert called["photo"] == "http://img"
     row = conn.execute("SELECT tg_file_id FROM moderation_queue WHERE id=1").fetchone()
     assert row["tg_file_id"] == "fid1"
+    assert db.get_cached_file_id(conn, "http://img") == "fid1"
+
+
+def test_publisher_message_with_image_url_sends_photo(monkeypatch):
+    conn = db.connect(":memory:")
+    db.init_schema(conn)
+    monkeypatch.setattr(publisher.db, "connect", lambda: conn)
+    monkeypatch.setattr(config, "ATTACH_IMAGES", True)
+    called = {}
+
+    def fake_send_photo(chat_id, photo, caption, parse_mode):
+        called["photo"] = photo
+        return ("m1", "fid2")
+
+    def fake_send_text(chat_id, text, parse_mode):
+        called["text"] = text
+        return "m2"
+
+    monkeypatch.setattr(publisher, "_send_photo", fake_send_photo)
+    monkeypatch.setattr(publisher, "_send_text", fake_send_text)
+
+    ok = publisher.publish_message("100", "t", "b", "u", image_url="http://img2", cfg=config)
+    assert ok is True
+    assert called["photo"] == "http://img2"
+    assert db.get_cached_file_id(conn, "http://img2") == "fid2"
 
 
 def test_preview_text_only(monkeypatch):


### PR DESCRIPTION
## Summary
- handle Telegram parse modes correctly and sanitize Markdown
- send photos via URL with file_id caching for direct and moderated posts
- validate images without fake file IDs and clean previous cache entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfc952691c8333af0e64f81cadf2aa