### PR TITLE
Improve image extraction and validation pipeline

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,7 +49,8 @@ RETRY_LIMIT: int = int(os.getenv("RETRY_LIMIT", "3"))
 
 # === HTTP-клиент ===
 HTTP_TIMEOUT_CONNECT: float = float(os.getenv("HTTP_TIMEOUT_CONNECT", "5"))
-HTTP_TIMEOUT_READ: float = float(os.getenv("HTTP_TIMEOUT_READ", "15"))
+# ТЗ: смягчённые таймауты (connect=5s, read=10s)
+HTTP_TIMEOUT_READ: float = float(os.getenv("HTTP_TIMEOUT_READ", "10"))
 HTTP_RETRY_TOTAL: int = int(os.getenv("HTTP_RETRY_TOTAL", "3"))
 HTTP_BACKOFF: float = float(os.getenv("HTTP_BACKOFF", "0.5"))
 

--- a/media/extractor.py
+++ b/media/extractor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from html import unescape
 from typing import List
@@ -7,34 +8,101 @@ from urllib.parse import urljoin
 
 from rewriter.base import NewsItem
 
-_META_RE = re.compile(r'<meta[^>]+?(?:property|name)="(?:og:image|twitter:image)"[^>]+?content="([^"]+)"', re.I)
+# regexes for various sources
+_META_OG = re.compile(r'<meta[^>]+?property="og:image"[^>]+?content="([^"]+)"', re.I)
+_META_OG_SEC = re.compile(r'<meta[^>]+?property="og:image:secure_url"[^>]+?content="([^"]+)"', re.I)
+_META_TW = re.compile(r'<meta[^>]+?name="twitter:image"[^>]+?content="([^"]+)"', re.I)
+_JSON_LD_RE = re.compile(r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>', re.I | re.S)
 _IMG_RE = re.compile(
-    r'<img[^>]+(?:src|data-src|data-original)=["\']([^"\']+)["\']', re.I
+    r'<img[^>]+(?:src|data-src|data-original|data-lazy)=["\']([^"\']+)["\']',
+    re.I,
 )
-_SRCSET_RE = re.compile(r'<(?:img|source)[^>]+srcset=["\']([^"\']+)["\']', re.I)
+_SRCSET_RE = re.compile(
+    r'<(?:img|source)[^>]+(?:srcset|data-srcset)=["\']([^"\']+)["\']',
+    re.I,
+)
+
+_PLACEHOLDER_RE = re.compile(
+    r"(no[-_]?image|placeholder|plug|zaglushka|stub|default|spacer|1x1)",
+    re.I,
+)
+
+
+def _best_from_srcset(srcset: str) -> str | None:
+    """Return URL with largest width from srcset string."""
+    best_url = None
+    best_w = -1
+    for part in srcset.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        url, *rest = part.split()
+        width = 0
+        if rest:
+            m = re.search(r"(\d+)(w|x)", rest[0])
+            if m:
+                width = int(m.group(1))
+        if width > best_w:
+            best_w = width
+            best_url = url
+    return best_url
+
+
+def _json_ld_image_urls(block: str) -> List[str]:
+    urls: List[str] = []
+    try:
+        data = json.loads(unescape(block))
+    except Exception:
+        return urls
+
+    def _extract(obj):
+        if isinstance(obj, str):
+            urls.append(obj)
+        elif isinstance(obj, list):
+            for it in obj:
+                _extract(it)
+        elif isinstance(obj, dict):
+            for key in ("image", "thumbnailUrl", "url", "@id"):
+                if key in obj:
+                    _extract(obj[key])
+    _extract(data)
+    return urls
 
 
 def extract_image_urls(item: NewsItem) -> List[str]:
-    urls: List[str] = []
-    if item.images:
-        urls.extend(item.images)
-    if item.html:
-        html = unescape(item.html)
-        urls.extend(_META_RE.findall(html))
-        urls.extend(_IMG_RE.findall(html))
-        for srcset in _SRCSET_RE.findall(html):
-            first = srcset.split(",")[0].strip().split(" ")[0]
-            if first:
-                urls.append(first)
-    seen = set()
+    """Extract candidate image URLs from ``item`` ordered by priority."""
     out: List[str] = []
-    for u in urls:
-        if not u:
+    html = unescape(item.html or "")
+
+    # meta tags in priority
+    for rx in (_META_OG, _META_OG_SEC, _META_TW):
+        out.extend(rx.findall(html))
+
+    # JSON-LD blocks
+    for block in _JSON_LD_RE.findall(html):
+        out.extend(_json_ld_image_urls(block))
+
+    # <picture>/<img> with srcset
+    for srcset in _SRCSET_RE.findall(html):
+        best = _best_from_srcset(srcset)
+        if best:
+            out.append(best)
+
+    # <img> with various attributes
+    out.extend(_IMG_RE.findall(html))
+
+    # normalize and filter placeholders
+    seen = set()
+    final: List[str] = []
+    for url in out:
+        if not url:
             continue
         if item.url:
-            u = urljoin(item.url, u)
-        if u in seen:
+            url = urljoin(item.url, url)
+        if url in seen:
             continue
-        seen.add(u)
-        out.append(u)
-    return out
+        if _PLACEHOLDER_RE.search(url):
+            continue
+        seen.add(url)
+        final.append(url)
+    return final

--- a/media/scorer.py
+++ b/media/scorer.py
@@ -3,20 +3,27 @@ from __future__ import annotations
 from typing import List, Optional
 import re
 
-
-BAD_KEYWORDS = {"logo", "sprite", "icon", "advert", "1x1", "pixel"}
+# Keywords signalling low-quality images
+BAD_KEYWORDS = {"logo", "sprite", "icon"}
+_PLACEHOLDER_RE = re.compile(
+    r"(no[-_]?image|placeholder|plug|zaglushka|stub|default|spacer|1x1)",
+    re.I,
+)
 
 
 def score_url(url: str) -> int:
+    """Heuristically score ``url`` to favour large non-placeholder images."""
     low = url.lower()
+    if _PLACEHOLDER_RE.search(low):
+        return -100
     score = 0
     if any(k in low for k in BAD_KEYWORDS):
-        score -= 10
-    if low.endswith(('.gif', '.webp')):
-        score -= 5
-    m = re.search(r'(\d+)x(\d+)', low)
-    if m and (m.group(1) == '1' or m.group(2) == '1'):
-        score -= 5
+        score -= 20
+    m = re.search(r"(\d{2,4})x(\d{2,4})", low)
+    if m:
+        score += int(m.group(1)) + int(m.group(2))
+    if "@2x" in low or "@3x" in low:
+        score += 10
     return score
 
 

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -27,11 +27,11 @@ class Resp:
 def test_no_fake_tg_file_id_generated(monkeypatch):
     calls = {"head": 0, "get": 0}
 
-    def fake_head(url, timeout, allow_redirects=True):
+    def fake_head(url, timeout, allow_redirects=True, headers=None):
         calls["head"] += 1
         return Resp(PNG_DATA)
 
-    def fake_get(url, timeout):
+    def fake_get(url, timeout, headers=None, allow_redirects=True):
         calls["get"] += 1
         return Resp(PNG_DATA)
 

--- a/tests/test_image_fallback.py
+++ b/tests/test_image_fallback.py
@@ -25,7 +25,7 @@ def test_resolve_image_uses_fallback_when_candidate_invalid(monkeypatch):
     monkeypatch.setattr(config, "FALLBACK_IMAGE_URL", "http://fallback/img.png")
 
     # probe_image returns None for any URL to emulate validation failure
-    monkeypatch.setattr(images, "probe_image", lambda url: None)
+    monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
 
     item = {"title": "t", "content": '<img src="http://bad/img.png">'}
     info = images.resolve_image(item)

--- a/tests/test_images_filters.py
+++ b/tests/test_images_filters.py
@@ -8,10 +8,13 @@ from WebWork import images
 def test_extract_candidates_filters():
     item = {
         "image_url": "http://mc.yandex.ru/counter.gif",
-        "content": '<img src="data:image/png;base64,xxx"><img src="http://example.com/logo.svg"><img src="http://good.com/pic.jpg">',
+        "content": '<img src="data:image/png;base64,xxx">'
+        '<img src="http://example.com/logo.svg">'
+        '<img src="http://site/no-image.png">'
+        '<img src="http://good.com/pic.jpg">',
     }
     cands = images.extract_candidates(item)
     urls = [c.url for c in cands]
     assert "http://good.com/pic.jpg" in urls
     assert all(u.endswith(".jpg") for u in urls)
-    assert not any("yandex" in u for u in urls)
+    assert not any("yandex" in u or "no-image" in u for u in urls)

--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -7,8 +7,25 @@ from rewriter.base import NewsItem
 from media.extractor import extract_image_urls
 
 
-def test_extract_from_html_meta_and_img_and_list():
-    html = '''<html><head><meta property="og:image" content="http://site/og.jpg"><meta name="twitter:image" content="http://site/tw.jpg"></head><body><img src="http://site/body.jpg"></body></html>'''
-    item = NewsItem(id="1", source="s", url="u", title="t", text="", html=html, images=["http://site/extra.jpg"])
+def test_extract_priority_and_filters():
+    html = '''<html><head>
+    <meta property="og:image" content="/og.jpg">
+    <meta property="og:image:secure_url" content="https://cdn/og-sec.jpg">
+    <meta name="twitter:image" content="http://site/tw.jpg">
+    <script type="application/ld+json">{"image": "ld.jpg", "thumbnailUrl": "/thumb.jpg"}</script>
+    </head><body>
+    <picture><source srcset="/img1.jpg 1x, /img2.jpg 2x"></picture>
+    <img data-src="img3.jpg">
+    <img src="http://site/no-image.png">
+    </body></html>'''
+    item = NewsItem(id="1", source="s", url="http://site/page", title="t", text="", html=html)
     urls = extract_image_urls(item)
-    assert urls == ["http://site/extra.jpg", "http://site/og.jpg", "http://site/tw.jpg", "http://site/body.jpg"]
+    assert urls == [
+        "http://site/og.jpg",
+        "https://cdn/og-sec.jpg",
+        "http://site/tw.jpg",
+        "http://site/ld.jpg",
+        "http://site/thumb.jpg",
+        "http://site/img2.jpg",
+        "http://site/img3.jpg",
+    ]


### PR DESCRIPTION
## Summary
- expand media extractor to gather images from meta tags, JSON-LD, srcset and filter placeholders
- add heuristics to score and select best candidate images
- harden image probing/downloading with proper headers, format conversion and Telegram fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd7987db88333a4fe44b1aaa569b6