### PR TITLE
Revamp image handling and Telegram sending

### DIFF
--- a/tests/test_image_fallback.py
+++ b/tests/test_image_fallback.py
@@ -2,7 +2,7 @@ import sys
 import pathlib
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from WebWork import images, config
+from WebWork import images
 
 
 def test_select_image_prefers_meta_tags():
@@ -12,8 +12,7 @@ def test_select_image_prefers_meta_tags():
     assert url == "http://site/og.jpg"
 
 
-def test_no_fallback_when_none_found(monkeypatch):
-    monkeypatch.setattr(config, "FALLBACK_IMAGE_URL", "http://fallback/img.png")
+def test_select_image_returns_none_when_none_found():
     item = {"title": "t", "content": "no images"}
     url = images.select_image(item)
     assert url is None
@@ -21,7 +20,6 @@ def test_no_fallback_when_none_found(monkeypatch):
 
 def test_resolve_image_returns_empty_when_invalid(monkeypatch):
     monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
-    monkeypatch.setattr(config, "FALLBACK_IMAGE_URL", "http://fallback/img.png")
     item = {"title": "t", "content": '<img src="http://bad/img.png">'}
     info = images.resolve_image(item)
     assert info == {}


### PR DESCRIPTION
## Summary
- replace image processing with robust module that extracts candidates, validates via HEAD/GET, caches metadata and returns prepared bytes
- send Telegram posts as photo uploads with MarkdownV2-safe captions
- adjust tests for new image pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfe6acda888333956beba3fc1df155