### PR TITLE
Add standalone autorewrite package

### DIFF
--- a/autorewrite/README.md
+++ b/autorewrite/README.md
@@ -1,0 +1,150 @@
+# autorewrite
+
+Автономный и быстрый рерайт новостных постов (без внешних ИИ-API). Подходит для Telegram-бота.
+
+## Возможности
+
+- Рерайт в 3 этапа (фолбэк-цепочка): мягкий → компрессия → усиленный.
+- Синонимизация/перефраз, перестановки, шаблоны новостного стиля.
+- Контроль длины (под лимит Telegram 4096).
+- Экранирование MarkdownV2.
+- Антидубликаты: шинглы (Jaccard) + SimHash (Хэмминг).
+- Простое API и CLI.
+
+## Установка
+
+```bash
+python -m venv .venv
+. .venv/bin/activate  # Windows: .\.venv\Scripts\activate
+pip install -e .
+```
+
+### CLI
+
+```
+python rewrite_cli.py --input "Текст новости..." --max-chars 3500 --min-distance 16
+```
+
+Или из файла:
+
+```
+python rewrite_cli.py --file input.txt
+```
+
+Вывод: JSON с полями title, text, similarity, distance, warnings.
+
+### Python API
+
+```python
+from rewriter.pipeline import rewrite_post
+
+res = rewrite_post(
+    text="Изначальный пост...",
+    desired_len=3500,
+    min_hamming_distance=16,  # SimHash
+    max_jaccard=0.85           # допустимая схожесть по шинглам
+)
+
+print(res["title"])
+print(res["text"])
+print(res["similarity"])
+print(res["distance"])
+print(res["warnings"])
+```
+
+### Интеграция с Telegram
+
+Используйте `rewriter.markdown.escape_markdown_v2(text)` перед отправкой сообщения.
+Следите за длиной: параметр `desired_len` в `rewrite_post`.
+
+### Настройка
+
+Словарь синонимов и шаблонов — в `rewriter/rules.py`. Расширяйте под собственный стиль/тематику (строительство, НН-регион).
+
+## `rewrite_cli.py`
+
+```python
+import argparse
+import json
+import sys
+from rewriter.pipeline import rewrite_post
+
+def main():
+    parser = argparse.ArgumentParser(description="Автономный рерайт новостных постов")
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--input", type=str, help="Входной текст")
+    g.add_argument("--file", type=str, help="Путь к текстовому файлу UTF-8")
+    parser.add_argument("--max-chars", type=int, default=3500, help="Максимальная длина результата")
+    parser.add_argument("--min-distance", type=int, default=16, help="Мин. дистанция SimHash (0..64)")
+    parser.add_argument("--max-jaccard", type=float, default=0.85, help="Макс. схожесть Jaccard по шинглам (0..1)")
+    parser.add_argument("--title-len", type=int, default=110, help="Желаемая длина заголовка")
+    args = parser.parse_args()
+
+    if args.input:
+        text = args.input
+    else:
+        try:
+            with open(args.file, "r", encoding="utf-8") as f:
+                text = f.read()
+        except Exception as e:
+            print(json.dumps({"error": f"Не удалось прочитать файл: {e}"}), ensure_ascii=False)
+            sys.exit(1)
+
+    res = rewrite_post(
+        text=text,
+        desired_len=args.max_chars,
+        min_hamming_distance=args.min_distance,
+        max_jaccard=args.max_jaccard,
+        desired_title_len=args.title_len,
+    )
+
+    print(json.dumps(res, ensure_ascii=False, indent=2))
+
+if __name__ == "__main__":
+    main()
+```
+
+### Как подключить к вашему боту
+
+Установите пакет (локально в вашем проекте):
+
+```
+pip install -e /путь/к/autorewrite
+```
+
+В коде бота используйте:
+
+```python
+from rewriter.pipeline import rewrite_post
+from rewriter.markdown import escape_markdown_v2
+
+def rewrite_and_prepare(text: str) -> str:
+    res = rewrite_post(
+        text=text,
+        desired_len=3500,
+        min_hamming_distance=18,
+        max_jaccard=0.80,
+        desired_title_len=100,
+    )
+    # формируем пост для Telegram (заголовок жирным)
+    title = res["title"]
+    body = res["text"]
+    msg = f"*{title}*\n\n{body}"
+    return escape_markdown_v2(msg)
+```
+
+Если у вас включена модерация — сохраняйте вместе с результатом метрики similarity и warnings, чтобы оператор видел причину фолбэка.
+
+### Почему это работает быстро и офлайн
+
+Никаких внешних API и моделей — только stdlib.
+Рерайт основан на детерминированных правилах и простых эвристиках для новостей.
+Антидубликаты — простые, но эффективные метрики (шинглы + SimHash).
+
+### Что можно улучшить (по желанию)
+
+- Расширить словарь SYNONYMS и PATTERNS под вашу лексику (строительство, НН-регион).
+- Добавить небольшой доменный классификатор (ключевые слова) перед рерайтом, чтобы не тратить ресурсы на нерелевантные тексты.
+- Подключить опциональный “тяжёлый” перефразер (например, локальную ONNX-модель) как дополнительный этап до/после правил — модуль легко расширяем.
+
+Если хотите — добавлю классификатор “Стройка+Нижегородская область” и связывающий код с вашими антидубликатами и модерацией.

--- a/autorewrite/pyproject.toml
+++ b/autorewrite/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=62"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autorewrite"
+version = "0.1.0"
+description = "Автономный быстрый рерайт новостных постов с фолбэком и антидубликатами"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [
+  { name = "ТГ — модуль рерайта", email = "dev@example.com" }
+]
+keywords = ["rewrite", "news", "telegram", "markdown", "simhash"]
+license = { text = "MIT" }
+
+[project.urls]
+Homepage = "https://example.local/autorewrite"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["rewriter*"]

--- a/autorewrite/rewrite_cli.py
+++ b/autorewrite/rewrite_cli.py
@@ -1,0 +1,40 @@
+import argparse
+import json
+import sys
+from rewriter.pipeline import rewrite_post
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Автономный рерайт новостных постов")
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--input", type=str, help="Входной текст")
+    g.add_argument("--file", type=str, help="Путь к текстовому файлу UTF-8")
+    parser.add_argument("--max-chars", type=int, default=3500, help="Максимальная длина результата")
+    parser.add_argument("--min-distance", type=int, default=16, help="Мин. дистанция SimHash (0..64)")
+    parser.add_argument("--max-jaccard", type=float, default=0.85, help="Макс. схожесть Jaccard по шинглам (0..1)")
+    parser.add_argument("--title-len", type=int, default=110, help="Желаемая длина заголовка")
+    args = parser.parse_args()
+
+    if args.input:
+        text = args.input
+    else:
+        try:
+            with open(args.file, "r", encoding="utf-8") as f:
+                text = f.read()
+        except Exception as e:
+            print(json.dumps({"error": f"Не удалось прочитать файл: {e}"}), ensure_ascii=False)
+            sys.exit(1)
+
+    res = rewrite_post(
+        text=text,
+        desired_len=args.max_chars,
+        min_hamming_distance=args.min_distance,
+        max_jaccard=args.max_jaccard,
+        desired_title_len=args.title_len,
+    )
+
+    print(json.dumps(res, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/autorewrite/rewriter/__init__.py
+++ b/autorewrite/rewriter/__init__.py
@@ -1,0 +1,4 @@
+from .pipeline import rewrite_post
+from .markdown import escape_markdown_v2
+
+__all__ = ["rewrite_post", "escape_markdown_v2"]

--- a/autorewrite/rewriter/markdown.py
+++ b/autorewrite/rewriter/markdown.py
@@ -1,0 +1,9 @@
+import re
+
+# Экранирование под Telegram MarkdownV2
+_TELEGRAM_MD_V2_SPECIALS = r'[_*\[\]()~`>#+\-=|{}.!]'
+
+def escape_markdown_v2(text: str) -> str:
+    if not text:
+        return text
+    return re.sub(r'([%s])' % re.escape(_TELEGRAM_MD_V2_SPECIALS), r'\\\1', text)

--- a/autorewrite/rewriter/pipeline.py
+++ b/autorewrite/rewriter/pipeline.py
@@ -1,0 +1,189 @@
+from typing import Dict, List, Tuple
+import re
+from .rules import (
+    split_sentences, apply_synonyms, apply_patterns, compact_whitespace,
+    squeeze_newlines, sentence_score, WORD_RE, LEADS, TAILS
+)
+from .similarity import normalize_for_shingles, shingles, jaccard, simhash, hamming_distance
+from .markdown import escape_markdown_v2
+
+
+def _limit_text(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    # стараемся резать по предложению
+    sents = split_sentences(text)
+    out = ""
+    for s in sents:
+        if len(out) + len(s) + 1 > max_len:
+            break
+        out += (s + " ")
+    out = out.strip()
+    if not out:
+        return text[:max_len]
+    return out
+
+
+def _make_title(text: str, desired_len: int = 110) -> str:
+    # базово: берем 1-е предложение, чистим вводные, режем до длины
+    sents = split_sentences(text)
+    base = sents[0] if sents else text
+    # упрощаем заголовок
+    base = re.sub(r"\b(сообщил[аи]?|рассказал[аи]?|заявил[аи]?|по словам|как сообщили)\b.*?$", "", base, flags=re.IGNORECASE)
+    base = re.sub(r"^\s*(В|Во|На|По)\s+", "", base, flags=re.IGNORECASE)
+    base = compact_whitespace(base)
+    base = apply_patterns(apply_synonyms(base))
+    if len(base) <= desired_len:
+        return base.rstrip(".")
+    # резка по словам
+    words = base.split()
+    out = []
+    cur = 0
+    for w in words:
+        if cur + len(w) + (1 if out else 0) > desired_len:
+            break
+        out.append(w)
+        cur += len(w) + (1 if out else 0)
+    return compact_whitespace(" ".join(out)).rstrip("—–-,:;")
+
+
+def _soft_rewrite(text: str) -> str:
+    # мягкая фаза: синонимы + паттерны, легкая перестановка 2-3 лидирующих предложений
+    sents = split_sentences(text)
+    if not sents:
+        return text
+    sents = [apply_patterns(apply_synonyms(s)) for s in sents]
+    # перестановка: если 2-3 предложения, меняем местами 1 и 2 (безопасно для новостей)
+    if len(sents) == 2:
+        sents = [sents[1], sents[0]]
+    elif len(sents) >= 3:
+        sents = [sents[1], sents[0]] + sents[2:]
+    out = " ".join(sents)
+    out = compact_whitespace(out)
+    return out
+
+
+def _compress(text: str, target_ratio: float = 0.85) -> str:
+    # отбор наиболее информативных предложений по простому скору
+    sents = split_sentences(text)
+    if not sents:
+        return text
+    scores = [(sentence_score(s), i, s) for i, s in enumerate(sents)]
+    scores.sort(reverse=True)  # по убыванию очков
+    # берем ~N * ratio предложений, минимум 2
+    n_take = max(2, int(len(sents) * target_ratio))
+    best = sorted(scores[:n_take], key=lambda x: x[1])  # восстановить естественный порядок
+    out = " ".join([x[2] for x in best])
+    return compact_whitespace(out)
+
+
+def _strong_rewrite(text: str) -> str:
+    # усиливаем шаблоном: лид + факты, плюс хвост-клише
+    sents = split_sentences(text)
+    if not sents:
+        return text
+    # core: 1–2 самых информативных
+    scores = [(sentence_score(s), i, s) for i, s in enumerate(sents)]
+    scores.sort(reverse=True)
+    core_sents = [x[2] for x in sorted(scores[:2], key=lambda y: y[1])]
+    core = compact_whitespace(" ".join(core_sents))
+    lead = LEADS[hash(text) % len(LEADS)].format(core=core)
+    body_sents = [apply_patterns(apply_synonyms(s)) for s in sents[2:5]]  # чуть-чуть истории
+    tail = TAILS[hash(core) % len(TAILS)]
+    out = " ".join([lead] + body_sents + [tail])
+    return compact_whitespace(out)
+
+
+def _similarity_metrics(src: str, dst: str) -> Dict[str, float]:
+    src_tokens = normalize_for_shingles(src)
+    dst_tokens = normalize_for_shingles(dst)
+    sh_a = shingles(src_tokens, 3)
+    sh_b = shingles(dst_tokens, 3)
+    jac = jaccard(sh_a, sh_b)
+    sh1 = simhash(src_tokens)
+    sh2 = simhash(dst_tokens)
+    dist = hamming_distance(sh1, sh2)  # 0..64
+    return {"jaccard": jac, "hamming": dist}
+
+
+def _final_polish(text: str) -> str:
+    text = compact_whitespace(text)
+    text = squeeze_newlines(text)
+    # точка в конце длинного поста
+    if text and text[-1] not in ".!?…":
+        text += "."
+    return text
+
+
+def rewrite_post(
+    text: str,
+    desired_len: int = 3500,
+    min_hamming_distance: int = 16,
+    max_jaccard: float = 0.85,
+    desired_title_len: int = 110,
+) -> Dict:
+    """
+    Главная функция рерайта.
+    Возвращает dict: {title, text, similarity: {jaccard, hamming}, warnings: [...]}. 
+    """
+    original = compact_whitespace(text or "")
+    warnings: List[str] = []
+    if not original:
+        return {
+            "title": "",
+            "text": "",
+            "similarity": {"jaccard": 0.0, "hamming": 64},
+            "warnings": ["Пустой входной текст"],
+        }
+
+    # Этап 1: мягкий
+    v1 = _soft_rewrite(original)
+    v1 = _limit_text(v1, desired_len)
+
+    m1 = _similarity_metrics(original, v1)
+
+    # Если уже ок по схожести — завершаем
+    if m1["hamming"] >= min_hamming_distance and m1["jaccard"] <= max_jaccard:
+        title = _make_title(v1, desired_len=desired_title_len)
+        out = _final_polish(v1)
+        return {
+            "title": title,
+            "text": out,
+            "similarity": m1,
+            "warnings": warnings,
+        }
+
+    # Этап 2: компрессия + легкий перефраз
+    v2_base = _compress(original, target_ratio=0.8)
+    v2 = _soft_rewrite(v2_base)
+    v2 = _limit_text(v2, desired_len)
+    m2 = _similarity_metrics(original, v2)
+
+    if m2["hamming"] >= min_hamming_distance and m2["jaccard"] <= max_jaccard:
+        title = _make_title(v2, desired_len=desired_title_len)
+        out = _final_polish(v2)
+        return {
+            "title": title,
+            "text": out,
+            "similarity": m2,
+            "warnings": ["Сработал фолбэк: компрессия+перефраз"],
+        }
+
+    # Этап 3: усиленный шаблонный рерайт
+    v3 = _strong_rewrite(original)
+    v3 = _limit_text(v3, desired_len)
+    m3 = _similarity_metrics(original, v3)
+
+    if not (m3["hamming"] >= min_hamming_distance and m3["jaccard"] <= max_jaccard):
+        warnings.append("Результат остаётся слишком похожим на оригинал по метрикам — проверьте вручную.")
+        warnings.append(f"Jaccard={m3['jaccard']:.3f} (порог {max_jaccard}), Hamming={int(m3['hamming'])} (порог {min_hamming_distance})")
+
+    title = _make_title(v3, desired_len=desired_title_len)
+    out = _final_polish(v3)
+
+    return {
+        "title": title,
+        "text": out,
+        "similarity": m3,
+        "warnings": warnings or ["Сработал фолбэк: усиленный шаблон"],
+    }

--- a/autorewrite/rewriter/rules.py
+++ b/autorewrite/rewriter/rules.py
@@ -1,0 +1,121 @@
+import re
+from typing import Dict, Pattern, List, Tuple
+
+# Базовый список стоп-слов (минимальный)
+STOP_WORDS_RU = {
+    "и","в","во","не","что","он","на","я","с","со","как","а","то","все","она","так",
+    "его","но","да","ты","к","у","же","вы","за","бы","по","ее","мне","есть","они",
+    "тут","о","эту","ли","если","мы","когда","вы","были","ещё","из","для","это","при",
+    "быть","от","до","после","г","год","лет","—","–"
+}
+
+# Доменные синонимы/замены под стройку и новости (расширяйте)
+SYNONYMS: Dict[str, str] = {
+    "построят": "возведут",
+    "построить": "возвести",
+    "строительство": "возведение",
+    "застройщик": "девелопер",
+    "введен в эксплуатацию": "запущен в работу",
+    "ввели в эксплуатацию": "запустили",
+    "ввести в эксплуатацию": "запустить в работу",
+    "началось": "стартовало",
+    "начался": "стартовал",
+    "начнется": "стартует",
+    "планируют": "намерены",
+    "планируется": "намечено",
+    "сообщил": "заявил",
+    "сообщила": "заявила",
+    "сообщили": "заявили",
+    "Нижегородской области": "Нижегородском регионе",
+    "Нижегородская область": "Нижегородский регион",
+    "Нижний Новгород": "Нижнем Новгороде",
+    "жилой комплекс": "ЖК",
+    "квартиры": "апартаменты",
+    "школа": "школьный корпус",
+    "детский сад": "дошкольное учреждение",
+    "инфраструктура": "объекты инфраструктуры",
+    "капитальный ремонт": "капремонт",
+    "ремонт": "ремонтные работы",
+    "реконструкция": "обновление",
+}
+
+# Паттерны простых перефраз (регекс → замена)
+PATTERNS: List[Tuple[Pattern[str], str]] = [
+    # пассив → актив (очень грубые эвристики)
+    (re.compile(r"\bбудет построен\b", flags=re.IGNORECASE), "планируют возвести"),
+    (re.compile(r"\bбудут построены\b", flags=re.IGNORECASE), "намерены возвести"),
+    (re.compile(r"\bбудет введен в эксплуатацию\b", flags=re.IGNORECASE), "планируют запустить"),
+    (re.compile(r"\bбудут введены в эксплуатацию\b", flags=re.IGNORECASE), "планируют запустить в работу"),
+    # канцелярит → нейтрально
+    (re.compile(r"\bв рамках\b", flags=re.IGNORECASE), "по проекту"),
+    (re.compile(r"\bв целях\b", flags=re.IGNORECASE), "чтобы"),
+    (re.compile(r"\bв том числе\b", flags=re.IGNORECASE), "включая"),
+]
+
+# Простые клише/шаблоны для усиленного рерайта
+LEADS = [
+    "Коротко: {core}.",
+    "Главное: {core}.",
+    "Суть: {core}.",
+    "Что произошло: {core}.",
+]
+
+TAILS = [
+    "Подробности — ниже.",
+    "Сроки и детали уточняются.",
+    "Проект реализуют поэтапно.",
+]
+
+# Разделители предложений (очень аккуратно)
+SENT_SPLIT_RE = re.compile(r"(?<=[\.!?])\s+")
+
+def split_sentences(text: str) -> List[str]:
+    text = text.strip()
+    if not text:
+        return []
+    # Сохраняем точки в числах/сокращениях грубой эвристикой — минимально
+    sents = SENT_SPLIT_RE.split(text)
+    # чистим пустые
+    return [s.strip() for s in sents if s.strip()]
+
+WORD_RE = re.compile(r"\b([А-ЯЁA-Z][а-яёa-z]+|[а-яёa-z]+|[A-Z]+|[0-9]+)\b", re.UNICODE)
+
+def smart_replace_wordcase(src: str, repl: str) -> str:
+    # Сохранение регистра: Слово -> Слово / слово -> слово / СЛОВО -> СЛОВО
+    if not src:
+        return repl
+    if src.isupper():
+        return repl.upper()
+    if src[0].isupper():
+        return repl.capitalize()
+    return repl
+
+def apply_synonyms(text: str) -> str:
+    # жадно по длинным ключам (чтобы "введен в эксплуатацию" шел раньше "эксплуатацию")
+    keys = sorted(SYNONYMS.keys(), key=len, reverse=True)
+    out = text
+    for k in keys:
+        # замена по словоформам будет ограниченной (русский сложен); используем точные вхождения/регистронезависимо
+        pattern = re.compile(re.escape(k), flags=re.IGNORECASE)
+        def _repl(m):
+            src = m.group(0)
+            return smart_replace_wordcase(src, SYNONYMS[k])
+        out = pattern.sub(_repl, out)
+    return out
+
+def apply_patterns(text: str) -> str:
+    out = text
+    for pat, repl in PATTERNS:
+        out = pat.sub(repl, out)
+    return out
+
+def compact_whitespace(s: str) -> str:
+    return re.sub(r"[ \t]+", " ", s).strip()
+
+def squeeze_newlines(s: str) -> str:
+    return re.sub(r"\n{3,}", "\n\n", s).strip()
+
+def sentence_score(sent: str) -> int:
+    # простая оценка "информативности": число значимых слов
+    tokens = [w.lower() for w in WORD_RE.findall(sent)]
+    return sum(1 for t in tokens if t not in STOP_WORDS_RU and len(t) > 2)

--- a/autorewrite/rewriter/similarity.py
+++ b/autorewrite/rewriter/similarity.py
@@ -1,0 +1,49 @@
+import hashlib
+import re
+from typing import Iterable, Set, Tuple, List
+
+_WORD_RE = re.compile(r"[А-Яа-яA-Za-z0-9\-]+")
+
+def normalize_for_shingles(s: str) -> List[str]:
+    tokens = [t.lower() for t in _WORD_RE.findall(s)]
+    return tokens
+
+def shingles(tokens: List[str], k: int = 3) -> Set[Tuple[str, ...]]:
+    if k <= 0:
+        return set()
+    return {tuple(tokens[i:i+k]) for i in range(max(0, len(tokens)-k+1))}
+
+def jaccard(a: Set[Tuple[str, ...]], b: Set[Tuple[str, ...]]) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+# Простой SimHash по словам
+def _hash64(x: str) -> int:
+    # Стабильный 64-битный хэш на базе sha1
+    h = hashlib.sha1(x.encode("utf-8")).digest()
+    # берем первые 8 байт
+    return int.from_bytes(h[:8], "big", signed=False)
+
+def simhash(tokens: Iterable[str]) -> int:
+    bits = 64
+    v = [0]*bits
+    for t in tokens:
+        h = _hash64(t)
+        for i in range(bits):
+            if (h >> i) & 1:
+                v[i] += 1
+            else:
+                v[i] -= 1
+    out = 0
+    for i in range(bits):
+        if v[i] >= 0:
+            out |= (1 << i)
+    return out
+
+def hamming_distance(a: int, b: int) -> int:
+    return (a ^ b).bit_count()

--- a/rewrite.py
+++ b/rewrite.py
@@ -1,30 +1,27 @@
 from __future__ import annotations
-import logging, re
-from typing import Iterable, List, Optional
+
+import logging
+import re
+from typing import Any, Dict
+
+from autorewrite.rewriter import rewrite_post
+
 log = logging.getLogger(__name__)
 
-_SENTENCE_SPLIT_RE = re.compile(r"(?<=[\.!?])\s+")
 _TAGS_RE = re.compile(r"<[^>]+>")
-_SYNONYMS: List[tuple[re.Pattern, str]] = [
-    (re.compile(r"\bсообщил(а|и)?\b"), "заявил\\1"),
-    (re.compile(r"\bсообщает\b"), "заявляет"),
-    (re.compile(r"\bсообщили\b"), "заявили"),
-    (re.compile(r"\bначал(ось|ась|ись)\b"), "стартовал\\1"),
-    (re.compile(r"\bпроходит\b"), "идёт"),
-    (re.compile(r"\bбыло завершено\b"), "завершили"),
-    (re.compile(r"\bв рамках\b"), "в составе"),
-    (re.compile(r"\bреализаци(я|и)\b"), "выполнени\\1"),
-    (re.compile(r"\bстроительств[оа]\b"), "возведение"),
-    (re.compile(r"\bреконструкци(я|и)\b"), "обновлени\\1"),
-]
-_DEFAULT_REGION_HINTS = ("нижегородская область","нижний новгород","дзержинск","бор","кстово","сормово","автозаводский район","канавинский район")
-_DEFAULT_TOPIC_HINTS = ("строи","жк","капремонт","реконструкц","ввод в эксплуатацию","подрядчик","генподряд","застройщик","инфраструктур","многоквартирн")
+
 
 def _get_cfg_attr(cfg, name: str, default):
-    try: return getattr(cfg, name)
-    except Exception: return default
+    try:
+        return getattr(cfg, name)
+    except Exception:
+        return default
 
-def _strip_tags(text: str) -> str: return _TAGS_RE.sub(" ", text or "")
+
+def _strip_tags(text: str) -> str:
+    return _TAGS_RE.sub(" ", text or "")
+
+
 def _normalize_ws(text: str) -> str:
     t = (text or "").replace("\xa0", " ")
     t = re.sub(r"[ \t]+", " ", t)
@@ -32,83 +29,60 @@ def _normalize_ws(text: str) -> str:
     t = re.sub(r"\n{3,}", "\n\n", t)
     return t.strip()
 
-def _split_sentences(text: str) -> List[str]:
-    text = _normalize_ws(text)
-    if not text: return []
-    parts = _SENTENCE_SPLIT_RE.split(text)
-    return [p.strip() for p in parts if p.strip()]
-
-def _join_sentences(sentences: Iterable[str]) -> str:
-    out = " ".join(s.strip() for s in sentences if s and s.strip())
-    return _normalize_ws(out)
-
-def _apply_synonyms(text: str) -> str:
-    t = f" {text} "
-    for pat, repl in _SYNONYMS:
-        try: t = pat.sub(repl, t)
-        except Exception: pass
-    return t.strip()
-
-def _prioritize_sentences(sentences: List[str], region_hints: Iterable[str], topic_hints: Iterable[str]) -> List[str]:
-    if not sentences: return sentences
-    def score(s: str) -> int:
-        sl = s.lower(); sc = 0
-        for h in region_hints:
-            if h in sl: sc += 2
-        for h in topic_hints:
-            if h in sl: sc += 1
-        return sc
-    indexed = list(enumerate(sentences))
-    indexed.sort(key=lambda t: (-score(t[1]), t[0]))
-    return [s for _, s in indexed]
 
 def _limit_length(text: str, max_chars: int) -> str:
-    if len(text) <= max_chars: return text
-    sentences = _split_sentences(text); out = ""
-    for s in sentences:
-        if len(out) + len(s) + 1 <= max_chars: out = (out + " " + s).strip()
-        else: break
-    if not out:
-        cut = text[:max_chars]
-        cut = re.sub(r"\s+\S*$", "", cut).strip()
-        return cut
-    return out
+    if len(text) <= max_chars:
+        return text
+    cut = text[:max_chars]
+    cut = re.sub(r"\s+\S*$", "", cut).strip()
+    return cut
 
-def _rewrite_via_external_ai(original: str, cfg) -> Optional[str]:
-    if not bool(_get_cfg_attr(cfg, "EXTERNAL_AI_ENABLED", False)): return None
-    return None
+
+def _rewrite(clean: str, cfg) -> Dict[str, Any]:
+    tg_limit = int(_get_cfg_attr(cfg, "TELEGRAM_MESSAGE_LIMIT", 4096))
+    rewrite_cap = int(_get_cfg_attr(cfg, "REWRITE_MAX_CHARS", min(900, tg_limit - 500)))
+    desired_len = max(200, min(rewrite_cap, tg_limit - 200))
+    return rewrite_post(text=clean, desired_len=desired_len)
+
 
 def rewrite_text(original: str, cfg) -> str:
+    """Rewrite raw text returning only rewritten body."""
     try:
-        if not original: return ""
+        if not original:
+            return ""
         if not bool(_get_cfg_attr(cfg, "ENABLE_REWRITE", True)):
             return _normalize_ws(_strip_tags(original))
-        ai_text = _rewrite_via_external_ai(original, cfg)
-        if ai_text:
-            result = _normalize_ws(_strip_tags(ai_text))
-        else:
-            clean = _normalize_ws(_strip_tags(original))
-            sentences = _split_sentences(clean)
-            region_hints = tuple(_get_cfg_attr(cfg, "REGION_KEYWORDS", _DEFAULT_REGION_HINTS))
-            topic_hints = tuple(_get_cfg_attr(cfg, "CONSTRUCTION_KEYWORDS", _DEFAULT_TOPIC_HINTS))
-            sentences = _prioritize_sentences(sentences, region_hints, topic_hints)
-            sentences_syn = [_apply_synonyms(s) for s in sentences]
-            result = _join_sentences(sentences_syn)
-        tg_limit = int(_get_cfg_attr(cfg, "TELEGRAM_MESSAGE_LIMIT", 4096))
-        rewrite_cap = int(_get_cfg_attr(cfg, "REWRITE_MAX_CHARS", min(900, tg_limit - 500)))
-        result = _limit_length(result, max_chars=max(200, min(rewrite_cap, tg_limit - 200)))
-        return result
-    except Exception as ex:
-        log.exception("Ошибка рерайта, используем бережное сокращение: %s", ex)
+        clean = _normalize_ws(_strip_tags(original))
+        res = _rewrite(clean, cfg)
+        return res.get("text", "")
+    except Exception as ex:  # pragma: no cover - defensive
+        log.exception("\u041e\u0448\u0438\u0431\u043a\u0430 \u0440\u0435\u0440\u0430\u0439\u0442\u0430, \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0435\u043c \u0431\u0435\u0440\u0435\u0436\u043d\u043e\u0435 \u0441\u043e\u043a\u0440\u0430\u0449\u0435\u043d\u0438\u0435: %s", ex)
         safe = _normalize_ws(_strip_tags(original))
         tg_limit = int(_get_cfg_attr(cfg, "TELEGRAM_MESSAGE_LIMIT", 4096))
-        return _limit_length(safe, max_chars=max(200, tg_limit - 200))
+        return _limit_length(safe, max(200, tg_limit - 200))
+
 
 def maybe_rewrite_item(item: dict, cfg) -> dict:
+    """Rewrite news item dict in-place-compatible way.
+
+    Returns a shallow copy of ``item`` with rewritten ``title`` and ``content``
+    when rewriting is enabled. Similarity metrics and warnings (if any) are
+    stored under ``rewrite_similarity`` and ``rewrite_warnings`` keys.
+    """
     try:
         out = dict(item)
-        summary = str(out.get("content", "") or "")
-        out["content"] = rewrite_text(summary, cfg)
+        if not bool(_get_cfg_attr(cfg, "ENABLE_REWRITE", True)):
+            out["content"] = _normalize_ws(_strip_tags(out.get("content", "") or ""))
+            return out
+        clean = _normalize_ws(_strip_tags(out.get("content", "") or ""))
+        res = _rewrite(clean, cfg)
+        out["content"] = res.get("text", "")
+        if res.get("title"):
+            out["title"] = res["title"]
+        if res.get("similarity"):
+            out["rewrite_similarity"] = res["similarity"]
+        if res.get("warnings"):
+            out["rewrite_warnings"] = res["warnings"]
         return out
-    except Exception:
+    except Exception:  # pragma: no cover - defensive
         return item


### PR DESCRIPTION
## Summary
- add `autorewrite` package with rule-based rewriting pipeline and CLI
- integrate autorewrite into post selection to rewrite titles and bodies with similarity metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfe995636c833399fadadabff03dc0