### PR TITLE
Improve config validation, filtering and image handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,33 @@
-TELEGRAM_BOT_TOKEN=
-MOD_CHAT_ID=
-TARGET_CHAT_ID=
-ALLOWED_MODERATORS=
-PARSE_MODE=HTML
-DISABLE_WEB_PAGE_PREVIEW=true
+# Telegram configuration
+TELEGRAM_BOT_TOKEN=            # required bot token
+CHANNEL_CHAT_ID=               # target channel id or @channel
+#CHANNEL_ID=                   # legacy channel id if needed
+ENABLE_MODERATION=0            # 1 to enable pre-moderation
+REVIEW_CHAT_ID=                # required when ENABLE_MODERATION=1
+MODERATOR_IDS=                 # comma separated user ids
+
+# Formatting
+PARSE_MODE=HTML                # or MarkdownV2
+CAPTION_LIMIT=1024
+TELEGRAM_MESSAGE_LIMIT=4096
+
+# Images
+ATTACH_IMAGES=1
+MIN_IMAGE_BYTES=4096
+IMAGE_TIMEOUT=15
+IMAGE_MIN_EDGE=220
+IMAGE_MIN_AREA=45000
+IMAGE_MIN_RATIO=0.5
+IMAGE_MAX_RATIO=3.0
+IMAGE_ALLOWED_DOMAINS=        # comma separated, empty = no limit
+IMAGE_ALLOWED_EXT=.jpg,.jpeg,.png,.webp
+FALLBACK_IMAGE_URL=https://via.placeholder.com/512
+
+# Filtering
+STRICT_FILTER=1
+FILTER_HEAD_CHARS=400
+WHITELIST_SOURCES=             # comma separated source names
+WHITELIST_RELAX=1
+
+# Database
+DB_PATH=

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ pip install beautifulsoup4
 
 ## Настройка
 Настройка выполняется один раз через `.env` в директории профиля пользователя
-(`%APPDATA%/NewsBot/.env` на Windows). Создать файл можно командой:
+(`%APPDATA%/NewsBot/.env` на Windows, `~/.config/NewsBot/.env` на Linux/macOS).
+Файл рядом с кодом `WebWork/.env` при наличии **переопределяет** значения из
+профильного. Создать основной файл можно командой:
 
 ```bash
 python -m config init
@@ -39,6 +41,19 @@ python -m config init
 
 В блоке `SOURCES` у каждого источника теперь есть флаг `enabled` и опциональные
 поля `timeout`/`retry` для индивидуальных сетевых настроек.
+
+## Быстрый старт
+1. Скопируйте `.env.example` в профиль пользователя:
+   ```bash
+   cp WebWork/.env.example ~/.config/NewsBot/.env  # для Windows путь %APPDATA%/NewsBot/.env
+   ```
+2. Укажите в файле обязательные параметры:
+   - `TELEGRAM_BOT_TOKEN` – токен бота;
+   - `CHANNEL_CHAT_ID` (или `CHANNEL_ID`) – целевой канал;
+   - при модерации (`ENABLE_MODERATION=1`) задайте `REVIEW_CHAT_ID` и `MODERATOR_IDS`.
+3. При необходимости скорректируйте лимиты Telegram и параметры изображений
+   (`CAPTION_LIMIT`, `TELEGRAM_MESSAGE_LIMIT`, `ATTACH_IMAGES`, `FALLBACK_IMAGE_URL`).
+4. Запустите `python main.py`.
 
 ## Запуск
 Разово:

--- a/filters.py
+++ b/filters.py
@@ -147,27 +147,20 @@ def is_relevant_for_source(title: str, content: str, source_name: str, cfg) -> T
     wl = set(_normalize_keywords(getattr(cfg, "WHITELIST_SOURCES", [])))
     relax = bool(getattr(cfg, "WHITELIST_RELAX", True))
 
+    ok, region_ok, topic_ok, reason = is_relevant(title, content, cfg)
     if src and src in wl and relax:
-        strict = bool(getattr(cfg, "STRICT_FILTER", True))
-        region_kw = _normalize_keywords(getattr(cfg, "REGION_KEYWORDS", []))
-        topic_kw  = _normalize_keywords(getattr(cfg, "CONSTRUCTION_KEYWORDS", []))
-        text_full = f"{title}\n{content}"
-        region_ok = contains_any(text_full, region_kw)
-        topic_ok  = contains_any(text_full, topic_kw)
-        ok = (region_ok and topic_ok) if strict else (region_ok or topic_ok)
+        ok = region_ok or topic_ok
         if ok:
             reason = ""
         else:
             if not region_ok and not topic_ok:
-                reason = "нет слов региона и тематики"
+                reason = "whitelist: нет слов региона и тематики"
             elif not region_ok:
-                reason = "нет слов региона"
+                reason = "whitelist: нет слов региона"
             else:
-                reason = "нет слов тематики"
+                reason = "whitelist: нет слов тематики"
         logger.debug(
             "is_relevant_for_source[WHITELIST] src='%s' => region=%s topic=%s title='%s'",
             source_name, region_ok, topic_ok, title[:120]
         )
-        return ok, region_ok, topic_ok, reason
-
-    return is_relevant(title, content, cfg)
+    return ok, region_ok, topic_ok, reason

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,20 @@
+import sys, pathlib, pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from WebWork import config
+
+
+def test_validate_config_missing(monkeypatch):
+    monkeypatch.setattr(config, "BOT_TOKEN", "")
+    monkeypatch.setattr(config, "CHANNEL_CHAT_ID", "")
+    monkeypatch.setattr(config, "CHANNEL_ID", "")
+    with pytest.raises(ValueError) as e:
+        config.validate_config()
+    assert "TELEGRAM_BOT_TOKEN" in str(e.value)
+
+
+def test_validate_config_ok(monkeypatch):
+    monkeypatch.setattr(config, "BOT_TOKEN", "x")
+    monkeypatch.setattr(config, "CHANNEL_CHAT_ID", "1")
+    monkeypatch.setattr(config, "ENABLE_MODERATION", False)
+    config.validate_config()

--- a/tests/test_filters_relevance.py
+++ b/tests/test_filters_relevance.py
@@ -1,0 +1,28 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from WebWork import filters
+
+
+class Cfg:
+    REGION_KEYWORDS = ["нижний", "область"]
+    CONSTRUCTION_KEYWORDS = ["строител", "смр"]
+    FILTER_HEAD_CHARS = 400
+    STRICT_FILTER = True
+    WHITELIST_SOURCES = {"trusted"}
+    WHITELIST_RELAX = True
+
+
+def test_relevant_strict_and_whitelist():
+    ok, r, t, reason = filters.is_relevant("нижний строители", "", Cfg)
+    assert ok and r and t and reason == ""
+
+    ok, r, t, reason = filters.is_relevant("нижний", "", Cfg)
+    assert not ok and r and not t and "тематики" in reason
+
+    ok, r, t, reason = filters.is_relevant_for_source("нижний", "", "trusted", Cfg)
+    assert ok and r and not t
+
+    Cfg.STRICT_FILTER = False
+    ok, r, t, reason = filters.is_relevant("", "смр", Cfg)
+    assert ok and not r and t

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -43,6 +43,7 @@ def test_no_fake_tg_file_id_generated(monkeypatch):
     monkeypatch.setattr(images, "MIN_WIDTH", 1)
     monkeypatch.setattr(images, "MIN_HEIGHT", 1)
     monkeypatch.setattr(images, "MIN_BYTES", 0)
+    monkeypatch.setattr(images, "MIN_AREA", 1)
     monkeypatch.setattr(images, "_probe_bytes", lambda raw: (1, 1, "image/png"))
 
     conn = db.connect(":memory:")

--- a/tests/test_image_fallback.py
+++ b/tests/test_image_fallback.py
@@ -5,21 +5,32 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from WebWork import images
 
 
-def test_select_image_prefers_meta_tags():
+def test_select_image_prefers_meta_tags(monkeypatch):
+    def fake_probe(url, referer=None):
+        if "og.jpg" in url:
+            return ("h1", 1000, 1000)
+        return ("h2", 100, 100)
+
+    monkeypatch.setattr(images, "probe_image", fake_probe)
     html = '<meta property="og:image" content="/og.jpg"><img src="/img.jpg">'
     item = {"title": "t", "url": "http://site/page", "content": html}
     url = images.select_image(item)
     assert url == "http://site/og.jpg"
 
 
-def test_select_image_returns_none_when_none_found():
+def test_select_image_returns_fallback_when_none_found(monkeypatch):
+    monkeypatch.setattr(images, "FALLBACK_IMAGE_URL", "http://fallback/pic.jpg")
+    monkeypatch.setattr(images, "ATTACH_IMAGES", True)
+    monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
     item = {"title": "t", "content": "no images"}
     url = images.select_image(item)
-    assert url is None
+    assert url == "http://fallback/pic.jpg"
 
 
-def test_resolve_image_returns_empty_when_invalid(monkeypatch):
+def test_resolve_image_returns_fallback_when_invalid(monkeypatch):
     monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
+    monkeypatch.setattr(images, "FALLBACK_IMAGE_URL", "http://fallback/pic.jpg")
+    monkeypatch.setattr(images, "ATTACH_IMAGES", True)
     item = {"title": "t", "content": '<img src="http://bad/img.png">'}
     info = images.resolve_image(item)
-    assert info == {}
+    assert info["image_url"] == "http://fallback/pic.jpg"

--- a/tests/test_publisher_preview.py
+++ b/tests/test_publisher_preview.py
@@ -1,0 +1,16 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from WebWork import publisher, config
+
+
+def test_compose_preview_limits_markdown():
+    title = "[title]" * 50
+    body = "_" * 5000
+    url = "https://example.com"
+    caption, long_text = publisher.compose_preview(title, body, url, "MarkdownV2")
+    assert len(caption) <= config.CAPTION_LIMIT
+    if long_text:
+        assert len(long_text) <= config.TELEGRAM_MESSAGE_LIMIT
+        assert not long_text.endswith("\\")
+    assert not caption.endswith("\\")


### PR DESCRIPTION
## Summary
- validate required environment variables with sensible defaults
- strengthen two-axis relevance filtering with whitelist relaxation
- refine image selection with domain/size checks and fallback placeholder
- enhance Telegram publisher escaping and photo reupload diagnostics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bffd11341c83338ef45a036cc3f1c3