### PR TITLE
Integrate image pipeline fallback for better image resolution

### DIFF
--- a/config.py
+++ b/config.py
@@ -110,6 +110,7 @@ MODERATOR_IDS: set[int] = {
 }
 ALLOWED_MODERATORS = MODERATOR_IDS
 ATTACH_IMAGES: bool = os.getenv("ATTACH_IMAGES", "true").lower() in {"1", "true", "yes"}
+ENABLE_IMAGE_PIPELINE: bool = os.getenv("ENABLE_IMAGE_PIPELINE", "false").lower() in {"1", "true", "yes"}
 MAX_MEDIA_PER_POST: int = int(os.getenv("MAX_MEDIA_PER_POST", "10"))
 IMAGE_MIN_EDGE: int = int(os.getenv("IMAGE_MIN_EDGE", "220"))
 IMAGE_MIN_AREA: int = int(os.getenv("IMAGE_MIN_AREA", "45000"))


### PR DESCRIPTION
## Summary
- Add `ENABLE_IMAGE_PIPELINE` config flag
- Use `image_pipeline` as a fallback in image selection to fetch article HTML and extract images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c025ea07208333b1f2bcd5b14ac804