### PR TITLE
Respect placeholder flag and shorten rewritten text

### DIFF
--- a/autorewrite/rewriter/pipeline.py
+++ b/autorewrite/rewriter/pipeline.py
@@ -154,7 +154,7 @@ def rewrite_post(clean_text: str, cfg: Any | None = None) -> Dict[str, Any]:
 
     max_jaccard = float(_get_cfg(cfg, "REWRITE_MAX_JACCARD", 0.72))
     min_hamming = int(_get_cfg(cfg, "REWRITE_MIN_HAMMING", 16))
-    max_chars = int(_get_cfg(cfg, "REWRITE_MAX_CHARS", 900))
+    max_chars = int(_get_cfg(cfg, "REWRITE_MAX_CHARS", 600))
     title_len = int(_get_cfg(cfg, "REWRITE_TITLE_LEN", 120))
 
     # soft rewrite

--- a/config.py
+++ b/config.py
@@ -545,7 +545,7 @@ RETRY_BACKOFF_SECONDS: float = float(os.getenv("RETRY_BACKOFF_SECONDS", "2.5"))
 PUBLISH_SLEEP_BETWEEN_SEC: float = float(os.getenv("PUBLISH_SLEEP_BETWEEN_SEC", "0"))
 
 # === Рерайт (опц.) ===
-REWRITE_MAX_CHARS = int(os.getenv("REWRITE_MAX_CHARS", "900"))
+REWRITE_MAX_CHARS = int(os.getenv("REWRITE_MAX_CHARS", "600"))
 EXTERNAL_AI_ENABLED = os.getenv("EXTERNAL_AI_ENABLED", "false").lower() in {"1", "true", "yes"}
 EXTERNAL_AI_ENDPOINT = os.getenv("EXTERNAL_AI_ENDPOINT", "")
 EXTERNAL_AI_KEY = os.getenv("EXTERNAL_AI_KEY", "")

--- a/images.py
+++ b/images.py
@@ -61,7 +61,7 @@ ALLOWED_EXT = {
 }
 FALLBACK_IMAGE_URL = getattr(config, "FALLBACK_IMAGE_URL", "")
 ATTACH_IMAGES = bool(getattr(config, "ATTACH_IMAGES", True))
-ALLOW_PLACEHOLDER = False
+ALLOW_PLACEHOLDER = bool(getattr(config, "ALLOW_PLACEHOLDER", False))
 
 IMAGES_CACHE_DIR = Path(getattr(config, "IMAGES_CACHE_DIR", "./cache/images"))
 MAX_SIDE = 1600
@@ -251,7 +251,7 @@ def select_image(item: Dict, cfg=config) -> Optional[str]:
                 return best_ext.url
         except Exception:
             logger.debug("image_pipeline fallback failed", exc_info=True)
-    if ATTACH_IMAGES and FALLBACK_IMAGE_URL:
+    if ATTACH_IMAGES and FALLBACK_IMAGE_URL and ALLOW_PLACEHOLDER:
         return FALLBACK_IMAGE_URL
     return None
 
@@ -567,7 +567,7 @@ def resolve_image(item: Dict, conn: Optional[sqlite3.Connection] = None) -> Dict
     payload = download_image(url, referer=item.get("url"))
     if not payload:
         image_stats["download_fail"] += 1
-        if ATTACH_IMAGES and FALLBACK_IMAGE_URL:
+        if ATTACH_IMAGES and FALLBACK_IMAGE_URL and ALLOW_PLACEHOLDER:
             return {"image_url": FALLBACK_IMAGE_URL}
         return {}
 

--- a/rewriter/__init__.py
+++ b/rewriter/__init__.py
@@ -12,7 +12,7 @@ from .llm import LLMRewriter, LLMConfig
 @dataclass
 class RewriterChainConfig:
     order: List[str] = field(default_factory=lambda: ["llm", "rules", "noop"])
-    target_length: int = 900
+    target_length: int = 600
     llm: LLMConfig = field(default_factory=LLMConfig)
     rules: RuleConfig = field(default_factory=RuleConfig)
 

--- a/tests/test_image_fallback.py
+++ b/tests/test_image_fallback.py
@@ -21,6 +21,7 @@ def test_select_image_prefers_meta_tags(monkeypatch):
 def test_select_image_returns_fallback_when_none_found(monkeypatch):
     monkeypatch.setattr(images, "FALLBACK_IMAGE_URL", "http://fallback/pic.jpg")
     monkeypatch.setattr(images, "ATTACH_IMAGES", True)
+    monkeypatch.setattr(images, "ALLOW_PLACEHOLDER", True)
     monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
     item = {"title": "t", "content": "no images"}
     url = images.select_image(item)
@@ -31,6 +32,7 @@ def test_resolve_image_returns_fallback_when_invalid(monkeypatch):
     monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
     monkeypatch.setattr(images, "FALLBACK_IMAGE_URL", "http://fallback/pic.jpg")
     monkeypatch.setattr(images, "ATTACH_IMAGES", True)
+    monkeypatch.setattr(images, "ALLOW_PLACEHOLDER", True)
     item = {"title": "t", "content": '<img src="http://bad/img.png">'}
     info = images.resolve_image(item)
     assert info["image_url"] == "http://fallback/pic.jpg"

--- a/tests/test_image_selection.py
+++ b/tests/test_image_selection.py
@@ -19,6 +19,7 @@ def test_select_image_returns_fallback_when_none_found(monkeypatch):
     monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
     monkeypatch.setattr(images, "FALLBACK_IMAGE_URL", "http://fallback/pic.jpg")
     monkeypatch.setattr(images, "ATTACH_IMAGES", True)
+    monkeypatch.setattr(images, "ALLOW_PLACEHOLDER", True)
     item = {"title": "t", "content": "no images"}
     url = images.select_image(item)
     assert url == "http://fallback/pic.jpg"
@@ -28,6 +29,7 @@ def test_resolve_image_returns_fallback_when_candidate_invalid(monkeypatch):
     monkeypatch.setattr(images, "probe_image", lambda url, referer=None: None)
     monkeypatch.setattr(images, "FALLBACK_IMAGE_URL", "http://fallback/pic.jpg")
     monkeypatch.setattr(images, "ATTACH_IMAGES", True)
+    monkeypatch.setattr(images, "ALLOW_PLACEHOLDER", True)
     item = {"title": "t", "content": '<img src="http://bad/img.png">'}
     info = images.resolve_image(item)
     assert info["image_url"] == "http://fallback/pic.jpg"

--- a/tg_news/config.example.yml
+++ b/tg_news/config.example.yml
@@ -81,7 +81,7 @@ filters:
   rewriter:
     enabled: true
     order: ["llm", "rules", "noop"]
-    target_length: 900
+    target_length: 600
     llm:
       provider: "openai"
       model: "gpt-4o-mini"


### PR DESCRIPTION
## Summary
- Only use fallback images when `ALLOW_PLACEHOLDER` is enabled
- Reduce default rewrite length to 600 characters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c11ae18fb08333bcb2f0c328ae73bf