### PR TITLE
Fix missing imports for image modules

### DIFF
--- a/context_images.py
+++ b/context_images.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import random
 from typing import Dict, Optional
 
-try:  # pragma: no cover - optional package structure
-    from . import config, images
+try:  # pragma: no cover - allow usage both as a package and standalone module
+    from . import config, images, net  # type: ignore
 except ImportError:  # pragma: no cover
+    # When executed as a script, fall back to absolute imports
     import config  # type: ignore
     import images  # type: ignore
     import net  # type: ignore

--- a/images.py
+++ b/images.py
@@ -12,8 +12,9 @@ from typing import Dict, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 try:
-    from . import config, db, context_images  # type: ignore
-except ImportError:  # pragma: no cover
+    from . import config, db, context_images, net  # type: ignore
+except ImportError:  # pragma: no cover - fall back to absolute imports when
+    # running as a standalone script
     import config  # type: ignore
     import db  # type: ignore
     import context_images  # type: ignore


### PR DESCRIPTION
## Summary
- Ensure `net` is imported in `images` regardless of package context
- Import `json` and `net` properly in `context_images`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1386a18388333a3a63af8e43e55f5