### PR TITLE
Enhance moderation previews with metadata

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,6 +99,11 @@ def run_once(conn) -> Tuple[int, int, int, int, int, int, int, int]:
                 continue
 
             # отправка
+            filter_meta = {
+                "region": bool(region_ok),
+                "topic": bool(topic_ok),
+            }
+
             item_clean = {
                 "source": src,
                 "source_id": src,
@@ -109,6 +114,7 @@ def run_once(conn) -> Tuple[int, int, int, int, int, int, int, int]:
                 "summary": it.get("summary") or "",
                 "published_at": it.get("published_at") or "",
                 "tags": list(tags),
+                "reasons": filter_meta,
             }
 
             item_clean = rewrite.maybe_rewrite_item(item_clean, config)

--- a/tests/test_moderation_queue.py
+++ b/tests/test_moderation_queue.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import pathlib
 import sqlite3
@@ -40,10 +41,17 @@ def test_queue_and_publish(monkeypatch):
         "content": "c",
         "summary": "s",
         "image_url": "",
+        "tags": ["nn", "строительство"],
+        "reasons": {"region": True, "topic": True},
     }
 
     mod_id = moderator.enqueue_item(item, conn)
     assert mod_id is not None
+    row = conn.execute(
+        "SELECT tags, reasons FROM moderation_queue WHERE id=?", (mod_id,)
+    ).fetchone()
+    assert json.loads(row["tags"]) == ["nn", "строительство"]
+    assert json.loads(row["reasons"]) == {"region": True, "topic": True}
     moderator.send_preview(conn, mod_id)
     assert preview_calls == {"chat": "100", "id": mod_id}
     assert moderator.is_moderator(1)

--- a/tests/test_publisher_moderation.py
+++ b/tests/test_publisher_moderation.py
@@ -1,0 +1,52 @@
+import time
+
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from WebWork import publisher, config
+
+
+def test_send_moderation_preview_includes_header(monkeypatch):
+    monkeypatch.setattr(config, "TELEGRAM_PARSE_MODE", "HTML")
+
+    calls = []
+
+    def fake_send_text(chat_id, text, parse_mode, reply_markup=None, reply_to_message_id=None):
+        calls.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "reply_markup": reply_markup,
+                "reply_to": reply_to_message_id,
+                "parse_mode": parse_mode,
+            }
+        )
+        return f"msg{len(calls)}"
+
+    monkeypatch.setattr(publisher, "_send_text", fake_send_text)
+    monkeypatch.setattr(publisher, "_send_with_retry", lambda action, cfg: action())
+
+    item = {
+        "title": "Заголовок",
+        "content": "Текст новости",
+        "url": "https://example.com",
+        "source": "Источник",
+        "tags": ["тест", "нижний"],
+        "reasons": {"region": True, "topic": False},
+        "fetched_at": int(time.time()) - 300,
+    }
+
+    mid = publisher.send_moderation_preview("chat", item, 5, cfg=config)
+
+    assert mid == "msg1"
+    assert calls, "ожидался хотя бы один вызов отправки"
+    first = calls[0]["text"]
+    assert first.startswith("🗞")
+    assert "#5" in first
+    assert "Источник" in first
+    assert "🏷️" in first
+    assert "Фильтр" in first
+    assert calls[0]["reply_markup"] is not None
+    assert calls[0]["reply_to"] is None
+    assert calls[0]["parse_mode"] == "HTML"


### PR DESCRIPTION
## Summary
- store tag and filter metadata with each moderation queue item so it is available when reloading from the database
- enrich moderation previews with a structured header that shows source, freshness, tags, and filter status alongside quick action guidance
- cover the new behaviour with tests for queue persistence and preview formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4f91312708333a65997f78c12d1c1