### PR TITLE
Allow review chat callbacks when acting as channel

### DIFF
--- a/moderator.py
+++ b/moderator.py
@@ -306,7 +306,12 @@ def handle_callback(conn: sqlite3.Connection, update: dict) -> Optional[str]:
     except Exception:
         return None
     extra = rest[0] if rest else None
-    if not is_moderator(user_id):
+    allowed = is_moderator(user_id)
+    if not allowed:
+        sender_chat = cb.get("message", {}).get("sender_chat")
+        if sender_chat and is_sender_authorized(sender_chat):
+            allowed = True
+    if not allowed:
         logger.warning("unauthorized callback", extra={"user_id": user_id, "action": action})
         return "forbidden"
     result: Optional[str] = None

--- a/tests/test_bot_updates_sender_chat.py
+++ b/tests/test_bot_updates_sender_chat.py
@@ -73,3 +73,36 @@ def test_sender_chat_denied(monkeypatch):
     bot_updates._handle_update(conn, None, update)
 
     assert denied == [("-200", "Нет доступа")]
+
+
+def test_callback_sender_chat_allowed(monkeypatch):
+    monkeypatch.setattr(config, "MODERATOR_IDS", set())
+    monkeypatch.setattr(config, "REVIEW_CHAT_ID", "-100")
+
+    conn = db.connect(":memory:")
+    db.init_schema(conn)
+
+    approved: list[tuple[int, int]] = []
+
+    def fake_approve(conn_arg, mod_id, user_id, text_override=None):
+        approved.append((mod_id, user_id))
+        return True
+
+    monkeypatch.setattr(moderator, "approve", fake_approve)
+
+    update = {
+        "callback_query": {
+            "id": "cb:1",
+            "data": "mod:1:approve",
+            "from": {},
+            "message": {
+                "chat": {"id": -100},
+                "sender_chat": {"id": -100},
+            },
+        }
+    }
+
+    action = moderator.handle_callback(conn, update)
+
+    assert action == "approve"
+    assert approved == [(1, 0)]


### PR DESCRIPTION
## Summary
- allow inline callback actions from review chat entities configured via REVIEW_CHAT_ID
- keep logging unauthorized callbacks while supporting channel-acting moderators
- add regression test covering sender_chat callbacks in moderation flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50fb83e34833382ae934e7c918e21