### PR TITLE
Fix raw moderation chat override

### DIFF
--- a/tests/test_raw_review_chat.py
+++ b/tests/test_raw_review_chat.py
@@ -1,0 +1,16 @@
+import importlib
+
+
+def test_raw_review_chat_prefers_specific_env(monkeypatch):
+    module = importlib.import_module("webwork.config")
+
+    # Ensure cached configuration does not leak between tests
+    module.load_all.cache_clear()  # type: ignore[attr-defined]
+
+    monkeypatch.setenv("REVIEW_CHAT_ID", "@main_mod")
+    monkeypatch.setenv("RAW_REVIEW_CHAT_ID", "@raw_mod")
+
+    cfg = module.load_all()  # type: ignore[call-arg]
+    assert cfg.raw.review_chat_id == "@raw_mod"
+
+    module.load_all.cache_clear()  # type: ignore[attr-defined]

--- a/webwork/config.py
+++ b/webwork/config.py
@@ -130,7 +130,7 @@ def load_all() -> AppConfig:
 
     raw_cfg = RawStreamCfg(
         enabled=_as_bool(_getenv("RAW_STREAM_ENABLED", default="false")),
-        review_chat_id=_getenv("REVIEW_CHAT_ID", "RAW_REVIEW_CHAT_ID"),
+        review_chat_id=_getenv("RAW_REVIEW_CHAT_ID", "REVIEW_CHAT_ID"),
         bypass_filters=_as_bool(_getenv("RAW_BYPASS_FILTERS", default="false")),
         bypass_dedup=_as_bool(_getenv("RAW_BYPASS_DEDUP", default="false")),
     )


### PR DESCRIPTION
## Summary
- prefer the RAW_REVIEW_CHAT_ID env var for the raw pipeline moderation chat instead of always reusing REVIEW_CHAT_ID
- add regression test ensuring the raw moderation chat can be configured separately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9b5fefd548333ab69162944df0161