### PR TITLE
Fix RAW deduplication across URL variants

### DIFF
--- a/tests/test_raw_pipeline_force.py
+++ b/tests/test_raw_pipeline_force.py
@@ -72,13 +72,57 @@ def test_raw_pipeline_runs_when_forced(monkeypatch, tmp_path, force_flag):
     # The message should be published once.
     assert len(published) == 1
 
-    # A second iteration should skip duplicates thanks to raw_dedup table.
+
+def test_raw_pipeline_detects_duplicates_across_url_variants(monkeypatch):
+    monkeypatch.setattr(raw_pipeline.config, "RAW_STREAM_ENABLED", True, raising=False)
+    monkeypatch.setattr(raw_pipeline.config, "RAW_BYPASS_DEDUP", False, raising=False)
+    monkeypatch.setattr(raw_pipeline.config, "RAW_REVIEW_CHAT_ID", "@raw_mod", raising=False)
+
+    def fake_fetch(session, source_url, timeout):
+        return [
+            raw_pipeline.RawPost(
+                channel_url=source_url,
+                alias="sample_channel",
+                message_id="123",
+                permalink=f"https://t.me/sample_channel/123",
+                content_text="Test body",
+                summary="",
+                links=[],
+                date_hint="",
+                fetched_at=0.0,
+            )
+        ]
+
+    monkeypatch.setattr(raw_pipeline, "fetch_tg_web_feed", fake_fetch)
+
+    published = []
+
+    def fake_publish(post):
+        published.append(post)
+        return True
+
+    monkeypatch.setattr(raw_pipeline, "publish_to_raw_review", fake_publish)
+    monkeypatch.setattr(raw_pipeline.http_client, "get_session", lambda: object())
+
+    conn = _setup_connection()
+    log = logging.getLogger("test.raw")
+
     raw_pipeline.run_raw_pipeline_once(
         None,
         conn,
         log,
-        force=not force_flag,
+        force=False,
         sources=["https://t.me/s/sample_channel"],
+    )
+
+    assert len(published) == 1
+
+    raw_pipeline.run_raw_pipeline_once(
+        None,
+        conn,
+        log,
+        force=False,
+        sources=["https://t.me/sample_channel"],
     )
 
     assert len(published) == 1


### PR DESCRIPTION
## Summary
- normalize RAW deduplication keys to use channel aliases instead of raw URLs
- add a regression test covering duplicate detection across `/s/` and canonical Telegram URLs

## Testing
- pytest tests/test_raw_pipeline_force.py

------
https://chatgpt.com/codex/tasks/task_e_68da47ddbfbc83339cf124df6de6b7f7