### PR TITLE
Downgrade transient Telegram send exceptions to warnings

### DIFF
--- a/publisher.py
+++ b/publisher.py
@@ -1003,8 +1003,13 @@ def _send_with_retry(action: Callable[[], Optional[str]], cfg=config) -> Optiona
     for attempt in range(retries + 1):
         try:
             mid = action()
-        except Exception:
-            log.exception("Ошибка отправки (попытка %s)", attempt + 1)
+        except Exception as exc:
+            log.warning(
+                "Ошибка отправки (попытка %s): %s",
+                attempt + 1,
+                exc,
+                exc_info=True,
+            )
             mid = None
         if mid:
             if attempt:


### PR DESCRIPTION
## Summary
- downgrade the retry logging in the Telegram sender so transient failures no longer appear as errors when a later retry succeeds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da76586ea08333853dfa57e1fe18bb