### PR TITLE
Prevent RAW republishing after failed deliveries

### DIFF
--- a/raw_pipeline.py
+++ b/raw_pipeline.py
@@ -599,10 +599,11 @@ def run_raw_pipeline_once(
                         duplicate_link,
                     )
                     continue
-            if publish_to_raw_review(post):
-                raw_mark_seen(conn, channel_key, msg_key, post.permalink or source_url)
-                raw_mark_links(conn, link_keys, post.permalink or source_url)
-                conn.commit()
+            published = publish_to_raw_review(post)
+            raw_mark_seen(conn, channel_key, msg_key, post.permalink or source_url)
+            raw_mark_links(conn, link_keys, post.permalink or source_url)
+            conn.commit()
+            if published:
                 new_count += 1
                 stats_new_posts += 1
             else:

--- a/tests/test_raw_pipeline_force.py
+++ b/tests/test_raw_pipeline_force.py
@@ -185,6 +185,59 @@ def test_raw_pipeline_skips_duplicate_links(monkeypatch):
     assert raw_pipeline.raw_link_is_dup(conn, raw_pipeline.canonical_url("https://example.com/news"))
 
 
+def test_raw_pipeline_records_failed_publication_once(monkeypatch):
+    monkeypatch.setattr(raw_pipeline.config, "RAW_STREAM_ENABLED", True, raising=False)
+    monkeypatch.setattr(raw_pipeline.config, "RAW_BYPASS_DEDUP", False, raising=False)
+    monkeypatch.setattr(raw_pipeline.config, "RAW_REVIEW_CHAT_ID", "@raw_mod", raising=False)
+
+    def fake_fetch(session, source_url, timeout):
+        return [
+            raw_pipeline.RawPost(
+                channel_url=source_url,
+                alias="sample_channel",
+                message_id="123",
+                permalink=f"{source_url.rstrip('/')}/123",
+                content_text="Test body",
+                summary="",
+                links=[],
+                date_hint="",
+                fetched_at=0.0,
+            )
+        ]
+
+    monkeypatch.setattr(raw_pipeline, "fetch_tg_web_feed", fake_fetch)
+
+    attempts: list[raw_pipeline.RawPost] = []
+
+    def fake_publish(post):
+        attempts.append(post)
+        return False
+
+    monkeypatch.setattr(raw_pipeline, "publish_to_raw_review", fake_publish)
+    monkeypatch.setattr(raw_pipeline.http_client, "get_session", lambda: object())
+
+    conn = _setup_connection()
+    log = logging.getLogger("test.raw")
+
+    raw_pipeline.run_raw_pipeline_once(
+        None,
+        conn,
+        log,
+        force=False,
+        sources=["https://t.me/s/sample_channel"],
+    )
+
+    # A failed publish should not be retried on the next tick thanks to dedup.
+    raw_pipeline.run_raw_pipeline_once(
+        None,
+        conn,
+        log,
+        force=False,
+        sources=["https://t.me/s/sample_channel"],
+    )
+
+    assert len(attempts) == 1
+
 def test_load_sources_by_branch_groups_channels(tmp_path):
     content = """
     # branch: alpha


### PR DESCRIPTION
## Summary
- ensure RAW pipeline records deduplication even if Telegram delivery fails so messages are not retried endlessly
- add regression test covering failed RAW publication dedup behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7f8f529c833390154b7360847914