### PR TITLE
Implement RAW channel deduplication guard

### DIFF
--- a/config.py
+++ b/config.py
@@ -78,6 +78,18 @@ _DEDUP_CFG = _dedup_cfg_loader()
 _RAW_CFG = _raw_cfg_loader()
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"", "0", "false", "no", "off"}:
+        return False
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    return default
+
+
 def _coerce_chat(value: str | None) -> str | int:
     if not value:
         return ""
@@ -242,7 +254,12 @@ if _RAW_FORWARD_STRATEGY not in {"copy", "forward", "link"}:
     _RAW_FORWARD_STRATEGY = "copy"
 RAW_FORWARD_STRATEGY: str = _RAW_FORWARD_STRATEGY
 RAW_BYPASS_FILTERS: bool = _RAW_CFG.bypass_filters
-RAW_BYPASS_DEDUP: bool = _RAW_CFG.bypass_dedup
+RAW_BYPASS_DEDUP: bool = _env_bool(
+    "RAW_BYPASS_DEDUP", bool(getattr(_RAW_CFG, "bypass_dedup", False))
+)
+RAW_CHANNEL_CHAT_ID: str = os.getenv("RAW_CHANNEL_CHAT_ID", "").strip()
+SEEN_DB_PATH: str = os.getenv("SEEN_DB_PATH", "seen.sqlite3").strip() or "seen.sqlite3"
+RAW_DEDUP_LOG: bool = _env_bool("RAW_DEDUP_LOG", True)
 RAW_MAX_PER_CHANNEL: int = int(os.getenv("RAW_MAX_PER_CHANNEL", "10"))
 RAW_MAX_CHANNELS_PER_TICK: int = int(os.getenv("RAW_MAX_CHANNELS_PER_TICK", "3"))
 RAW_CHANNEL_TIMEOUT_SEC: float = float(os.getenv("RAW_CHANNEL_TIMEOUT_SEC", "30"))

--- a/seen_store.py
+++ b/seen_store.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+
+try:  # pragma: no cover - optional package-relative import
+    from . import config
+except Exception:  # pragma: no cover - fallback when run as script
+    import config  # type: ignore
+
+
+_LOG = logging.getLogger("webwork.raw")
+_CONN: sqlite3.Connection | None = None
+
+
+def get_conn() -> sqlite3.Connection:
+    global _CONN
+    if _CONN is None:
+        db_path = getattr(config, "SEEN_DB_PATH", "seen.sqlite3")
+        _CONN = sqlite3.connect(db_path)
+        _CONN.row_factory = sqlite3.Row
+        _ensure_schema(_CONN)
+        if getattr(config, "RAW_DEDUP_LOG", True):
+            _LOG.debug("[RAW] открыт seen-store: %s", db_path)
+    return _CONN
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS seen_items (
+          key TEXT PRIMARY KEY,
+          first_seen INTEGER NOT NULL,
+          source_domain TEXT,
+          title TEXT
+        )
+        """
+    )
+    conn.commit()
+
+
+def is_seen(conn: sqlite3.Connection, key: str) -> bool:
+    cur = conn.execute("SELECT 1 FROM seen_items WHERE key = ?", (key,))
+    result = cur.fetchone() is not None
+    if getattr(config, "RAW_DEDUP_LOG", True):
+        _LOG.debug("[RAW] проверка seen: %s -> %s", key, result)
+    return result
+
+
+def mark_seen(
+    conn: sqlite3.Connection,
+    key: str,
+    *,
+    source_domain: str = "",
+    title: str = "",
+) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO seen_items (key, first_seen, source_domain, title) "
+        "VALUES (?, ?, ?, ?)",
+        (key, int(time.time()), source_domain, title),
+    )
+    conn.commit()
+    if getattr(config, "RAW_DEDUP_LOG", True):
+        _LOG.debug("[RAW] сохранён ключ: %s", key)


### PR DESCRIPTION
## Summary
- add configuration helpers for RAW deduplication settings and environment flags
- provide URL normalization and key generation helpers with SQLite-backed seen store
- integrate RAW duplicate detection and logging into the publisher flow

## Testing
- pytest tests/test_raw_pipeline_force.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd7261b4c8333a5b0cd7a1647cfae