### PR TITLE
Implement RAW dedup guard with persistent store

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,6 +63,7 @@ try:  # pragma: no cover - simple fallback handling
         ENABLE_MODERATION as DEFAULT_ENABLE_MODERATION,
         REVIEW_CHAT_ID as DEFAULT_REVIEW_CHAT_ID,
         MODERATOR_IDS as DEFAULT_MODERATOR_IDS,
+        DEDUP_DB_PATH as DEFAULT_DEDUP_DB_PATH,
     )
 except Exception:  # pragma: no cover - executed only when defaults missing
     DEFAULT_BOT_TOKEN = ""
@@ -70,6 +71,7 @@ except Exception:  # pragma: no cover - executed only when defaults missing
     DEFAULT_ENABLE_MODERATION = False
     DEFAULT_REVIEW_CHAT_ID = ""
     DEFAULT_MODERATOR_IDS: set[int] = set()
+    DEFAULT_DEDUP_DB_PATH = os.path.join("state", "seen.sqlite3")
 
 
 _TELEGRAM_CFG = _telegram_cfg_loader()
@@ -258,7 +260,10 @@ RAW_BYPASS_DEDUP: bool = _env_bool(
     "RAW_BYPASS_DEDUP", bool(getattr(_RAW_CFG, "bypass_dedup", False))
 )
 RAW_CHANNEL_CHAT_ID: str = os.getenv("RAW_CHANNEL_CHAT_ID", "").strip()
-SEEN_DB_PATH: str = os.getenv("SEEN_DB_PATH", "seen.sqlite3").strip() or "seen.sqlite3"
+DEDUP_DB_PATH: str = (
+    os.getenv("DEDUP_DB_PATH", DEFAULT_DEDUP_DB_PATH).strip() or DEFAULT_DEDUP_DB_PATH
+)
+SEEN_DB_PATH: str = os.getenv("SEEN_DB_PATH", DEDUP_DB_PATH).strip() or DEDUP_DB_PATH
 RAW_DEDUP_LOG: bool = _env_bool("RAW_DEDUP_LOG", True)
 RAW_MAX_PER_CHANNEL: int = int(os.getenv("RAW_MAX_PER_CHANNEL", "10"))
 RAW_MAX_CHANNELS_PER_TICK: int = int(os.getenv("RAW_MAX_CHANNELS_PER_TICK", "3"))

--- a/config_defaults.py
+++ b/config_defaults.py
@@ -9,8 +9,11 @@ Storing credentials in source code is insecure and not recommended for
 production deployments.
 """
 
+import os
+
 BOT_TOKEN = "YOUR_TELEGRAM_BOT_TOKEN"
 CHANNEL_ID = "@your_main_channel"
 ENABLE_MODERATION = True
 REVIEW_CHAT_ID = "@your_review_channel"
 MODERATOR_IDS = {123456789}
+DEDUP_DB_PATH = os.getenv("DEDUP_DB_PATH", os.path.join("state", "seen.sqlite3"))


### PR DESCRIPTION
## Summary
- add stronger canonicalisation helpers for RAW deduplication keys
- introduce an SQLite-backed SeenStore and guard the RAW pipeline before sending
- expose a configurable DEDUP_DB_PATH and adjust tests for the new behaviour

## Testing
- pytest tests/test_raw_pipeline_force.py

------
https://chatgpt.com/codex/tasks/task_e_68dcea4a8bf4833391530cf5803d4f9c