### PR TITLE
Fix canonical URL to drop trailing slashes before deduplication

### DIFF
--- a/webwork/dedup.py
+++ b/webwork/dedup.py
@@ -45,6 +45,8 @@ def canonical_url(url: Optional[str]) -> str:
     ]
     scheme = parsed.scheme.lower() or "https"
     path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/") or "/"
     return urlunparse((scheme, host, path, "", urlencode(clean_query, doseq=True), ""))
 
 


### PR DESCRIPTION
## Summary
- normalize canonical URL paths by trimming trailing slashes so that query strings are attached correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd091b0a2c8333afbd02c81c509c40