### PR TITLE
Refactor imports and dedup config loading

### DIFF
--- a/bot_updates.py
+++ b/bot_updates.py
@@ -3,17 +3,15 @@ if __name__ == "__main__" or __package__ is None:
     import os, sys
     sys.path.insert(0, os.path.dirname(__file__))
 
-try:
-    from . import config, db, http_client, moderator, publisher  # type: ignore
-except Exception:
-    import config, db, http_client, moderator, publisher  # type: ignore
+import config
+import db
+import http_client
+import moderator
+import publisher
 
 import time
 
-try:
-    from .logging_setup import get_logger  # type: ignore
-except Exception:  # pragma: no cover
-    from logging_setup import get_logger  # type: ignore
+from logging_setup import get_logger
 
 logger = get_logger(__name__)
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from platformdirs import user_config_dir
@@ -150,7 +151,19 @@ except Exception:  # pragma: no cover - executed only when defaults missing
 
 _TELEGRAM_CFG = _telegram_cfg_loader()
 _HTTP_CFG = _http_cfg_loader()
-_DEDUP_CFG = _dedup_cfg_loader()
+def _load_dedup_cfg(loader: Any):
+    if loader is None:
+        raise RuntimeError("dedup_config module not available")
+    if callable(loader):
+        return loader()
+    for attr in ("load", "dedup_cfg"):
+        target = getattr(loader, attr, None)
+        if callable(target):
+            return target()
+    raise TypeError("Unsupported dedup_config loader")
+
+
+_DEDUP_CFG = _load_dedup_cfg(_dedup_cfg_loader)
 _RAW_CFG = _raw_cfg_loader()
 
 

--- a/db.py
+++ b/db.py
@@ -12,10 +12,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 
-try:
-    from . import config
-except ImportError:  # pragma: no cover
-    import config  # type: ignore
+import config
 
 from logging_setup import get_logger
 

--- a/dedup.py
+++ b/dedup.py
@@ -16,12 +16,9 @@ from difflib import SequenceMatcher
 from typing import Dict, List, Optional, Sequence, Tuple
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-try:
-    from . import config, db, utils
-except ImportError:  # pragma: no cover
-    import config  # type: ignore
-    import db  # type: ignore
-    import utils  # type: ignore
+import config
+import db
+import utils
 
 from logging_setup import get_logger
 from webwork.dedup import (

--- a/fetcher.py
+++ b/fetcher.py
@@ -16,16 +16,11 @@ from urllib.parse import urljoin, urlparse
 import feedparser
 import requests
 
-try:
-    from . import config, dedup, net
-    from .utils import canonicalize_url, normalize_whitespace
-    from .parsers import html as html_parsers
-except ImportError:  # pragma: no cover
-    import config  # type: ignore
-    import dedup  # type: ignore
-    import net  # type: ignore
-    from utils import canonicalize_url, normalize_whitespace  # type: ignore
-    html_parsers = None  # type: ignore
+import config
+import dedup
+import net
+from parsers import html as html_parsers
+from utils import canonicalize_url, normalize_whitespace
 
 from logging_setup import get_logger
 
@@ -187,9 +182,11 @@ def _notify_service_chat(message: str) -> None:
         logger.debug("Пропущено уведомление в служебный чат: нет токена или DRY_RUN")
         return
     try:  # pragma: no cover - heavy dependency, not critical for tests
-        from . import publisher  # type: ignore
-    except ImportError:  # pragma: no cover - direct execution
         import publisher  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        publisher = None  # type: ignore[assignment]
+    if not publisher:
+        return
     try:
         publisher.send_message(str(chat_id), message, cfg=config)
     except Exception as exc:  # pragma: no cover - logging side effect

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -16,10 +16,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict
 
-try:  # pragma: no cover - package import for production/runtime
-    from . import config  # type: ignore
-except ImportError:  # pragma: no cover - direct script execution
-    import config  # type: ignore
+import config
 
 from webwork.logging_setup import SecretsFilter
 

--- a/main.py
+++ b/main.py
@@ -5,53 +5,30 @@ if __name__ == "__main__" or __package__ is None:
 
 import argparse
 import sys
-import time
 import threading
+import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
 
-try:  # pragma: no cover - package-relative imports when executed via -m
-    from . import (
-        bot_updates,
-        classifieds,
-        config,
-        dedup,
-        db,
-        filters,
-        http_client,
-        moderation,
-        moderator,
-        raw_pipeline,
-        rewrite,
-        tagging,
-    )
-    from .utils import compute_title_hash, normalize_whitespace
-    from .logging_setup import get_logger, init_logging
-except Exception:  # pragma: no cover - direct script execution fallback
-    # абсолютные импорты как fallback
-    # from .module -> import module
-    import bot_updates  # type: ignore
-    import classifieds  # type: ignore
-    import config  # type: ignore
-    import dedup  # type: ignore
-    import db  # type: ignore
-    import filters  # type: ignore
-    import http_client  # type: ignore
-    import moderation  # type: ignore
-    import moderator  # type: ignore
-    import raw_pipeline  # type: ignore
-    import rewrite  # type: ignore
-    import tagging  # type: ignore
-    from utils import compute_title_hash, normalize_whitespace  # type: ignore
-    from logging_setup import get_logger, init_logging  # type: ignore
+import bot_updates
+import classifieds
+import config
+import dedup
+import db
+import filters
+import http_client
+import moderation
+import moderator
+import raw_pipeline
+import rewrite
+import tagging
+from logging_setup import get_logger, init_logging
+from utils import compute_title_hash, normalize_whitespace
 
 try:  # pragma: no cover - publisher may be optional in tests
-    from . import publisher  # type: ignore
-except ImportError:  # pragma: no cover - executed when run as script
-    try:
-        import publisher  # type: ignore
-    except Exception:  # pragma: no cover
-        publisher = None  # type: ignore
+    import publisher
+except Exception:  # pragma: no cover
+    publisher = None  # type: ignore[assignment]
 
 logger = get_logger(__name__)
 

--- a/moderator.py
+++ b/moderator.py
@@ -10,11 +10,8 @@ import sqlite3
 import time
 from typing import Any, Dict, Optional
 
-try:
-    from . import config, publisher
-except ImportError:  # pragma: no cover
-    import config  # type: ignore
-    import publisher  # type: ignore
+import config
+import publisher
 
 from logging_setup import get_logger
 

--- a/net.py
+++ b/net.py
@@ -11,11 +11,8 @@ from typing import Optional, Dict
 
 import requests
 
-try:  # pragma: no cover
-    from . import config, http_client
-except Exception:  # pragma: no cover
-    import config  # type: ignore
-    import http_client  # type: ignore
+import config
+import http_client
 
 from logging_setup import get_logger
 

--- a/publisher.py
+++ b/publisher.py
@@ -7,28 +7,23 @@ if __name__ == "__main__" or __package__ is None:
 
 import json
 import logging
+import re
+import sqlite3
 import time
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, Optional, Sequence
-import re
-import sqlite3
 from urllib.parse import urlparse
 
 import requests
 
-from formatting import clean_html_tags, html_escape, truncate_by_chars
-
-import moderation
+import config
 import dedup
+import moderation
+import rewrite
 import seen_store
+from formatting import clean_html_tags, html_escape, truncate_by_chars
 from logging_setup import audit, get_logger, mask_secrets
-
-try:  # pragma: no cover - package import in production
-    from . import config, rewrite
-except ImportError:  # pragma: no cover - direct script execution
-    import config  # type: ignore
-    import rewrite  # type: ignore
 from webwork.utils.formatting import chunk_text, safe_format, TG_TEXT_LIMIT
 from webwork.router import route_and_publish
 

--- a/raw_pipeline.py
+++ b/raw_pipeline.py
@@ -25,12 +25,9 @@ import http_client
 from dedup import SeenStore
 from webwork.dedup import canonical_url, stable_text_key
 
-try:  # pragma: no cover - production style imports
-    from . import config, utils, publisher
-except ImportError:  # pragma: no cover - direct script execution
-    import config  # type: ignore
-    import utils  # type: ignore
-    import publisher  # type: ignore
+import config
+import publisher
+import utils
 
 
 logger = logging.getLogger(__name__)

--- a/seen_store.py
+++ b/seen_store.py
@@ -11,10 +11,7 @@ import logging
 import sqlite3
 import time
 
-try:  # pragma: no cover - optional package-relative import
-    from . import config
-except Exception:  # pragma: no cover - fallback when run as script
-    import config  # type: ignore
+import config
 
 
 _LOG = logging.getLogger("webwork.raw")

--- a/sources.py
+++ b/sources.py
@@ -5,11 +5,9 @@ if __name__ == "__main__" or __package__ is None:
     sys.path.insert(0, os.path.dirname(__file__))
 # end of shim
 
-from typing import Iterable, Dict
-try:
-    from . import config
-except ImportError:  # pragma: no cover
-    import config  # type: ignore
+from typing import Dict, Iterable
+
+import config
 
 def iter_sources() -> Iterable[Dict[str, str]]:
     for s in config.SOURCES:

--- a/sources_nn.py
+++ b/sources_nn.py
@@ -21,10 +21,8 @@ import yaml
 _DEFAULTS_CACHE: Dict[str, Any] | None = None
 _SOURCES_CACHE: List[Dict[str, Any]] | None = None
 _log = logging.getLogger("webwork.app.sources")
-try:  # pragma: no cover
-    from . import config  # пакетный импорт
-except Exception:  # pragma: no cover
-    import config  # прямой запуск
+
+import config
 
 VERSION_REQUIRED = 2
 _RUBRICS = {"kazusy", "objects", "persons"}

--- a/start.bat
+++ b/start.bat
@@ -1,34 +1,9 @@
 @echo off
 setlocal
-
-rem create and activate virtual environment
-if not exist ".venv" (
-    python -m venv .venv
-)
-call .venv\Scripts\activate
-
-rem install dependencies
-python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
-
-rem initialize configuration if missing
-set "ENV_PATH=%USERPROFILE%\NewsBot\.env"
-if not exist "%ENV_PATH%" (
-    if not exist "%USERPROFILE%\NewsBot" mkdir "%USERPROFILE%\NewsBot"
-    if exist ".env.example" (
-        python -m config init || copy ".env.example" "%ENV_PATH%"
-    )
-)
-
-rem run the bot with any passed arguments
-python main.py %*
-
-echo.
-echo Запуск завершён.
-echo Дальнейшие команды:
-echo   python main.py             # запуск одного прохода
-echo   python main.py --loop      # запуск в бесконечном цикле
-
-pause
-
+chcp 65001 >nul
+set "PYTHONUTF8=1"
+set "PYTHONIOENCODING=utf-8"
+if not exist ".venv\Scripts\python.exe" py -3 -m venv .venv
+call ".venv\Scripts\python.exe" -X utf8 -m pip install -r requirements.txt --no-cache-dir
+call ".venv\Scripts\python.exe" -X utf8 main.py %*
 endlocal

--- a/telegram_web.py
+++ b/telegram_web.py
@@ -19,10 +19,7 @@ from urllib.parse import urlparse
 import requests
 from bs4 import BeautifulSoup
 
-try:  # pragma: no cover - optional import during tests
-    from . import config  # type: ignore
-except ImportError:  # pragma: no cover - executed for direct runs
-    import config  # type: ignore
+import config
 
 logger = logging.getLogger(__name__)
 

--- a/webwork/dedup.py
+++ b/webwork/dedup.py
@@ -108,7 +108,9 @@ def near_duplicate(
 ) -> Optional[tuple[str, float]]:
     """Return the most similar candidate if "near duplicates" are enabled."""
 
-    cfg = dedup_config()
+    if dedup_config is None:
+        return None
+    cfg = dedup_config.load()
     if not cfg.near_duplicates_enabled:
         return None
     base = title_norm(title)

--- a/webwork/dedup_config.py
+++ b/webwork/dedup_config.py
@@ -1,0 +1,24 @@
+"""Lazy loader for deduplication configuration."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from .config import DedupCfg
+
+
+def _config_module():
+    return import_module(__name__.rsplit(".", 1)[0] + ".config")
+
+
+@lru_cache()
+def load() -> "DedupCfg":
+    """Return the deduplication configuration section."""
+
+    return _config_module().dedup_cfg()
+
+
+__all__ = ["load"]


### PR DESCRIPTION
## Summary
- break the circular dependency in `webwork.__init__` by lazily loading configuration and exposing the `dedup_config` module
- replace relative import fallbacks with direct absolute imports in the flat modules so they work when executed as scripts
- refresh `start.bat` and normalize tracked text files to UTF-8 as part of the encoding cleanup

## Testing
- python -m compileall webwork config.py bot_updates.py fetcher.py main.py


------
https://chatgpt.com/codex/tasks/task_e_68dd89fea74c8333acf39b2b3e0191e7