### PR TITLE
Ensure package modules share consistent imports

### DIFF
--- a/bot_updates.py
+++ b/bot_updates.py
@@ -3,11 +3,18 @@ if __name__ == "__main__" or __package__ is None:
     import os, sys
     sys.path.insert(0, os.path.dirname(__file__))
 
-import config
-import db
-import http_client
-import moderator
-import publisher
+try:
+    from . import config
+    from . import db
+    from . import http_client
+    from . import moderator
+    from . import publisher
+except ImportError:  # pragma: no cover - fallback when executed as script
+    import config  # type: ignore
+    import db  # type: ignore
+    import http_client  # type: ignore
+    import moderator  # type: ignore
+    import publisher  # type: ignore
 
 import time
 

--- a/dedup.py
+++ b/dedup.py
@@ -16,9 +16,14 @@ from difflib import SequenceMatcher
 from typing import Dict, List, Optional, Sequence, Tuple
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-import config
-import db
-import utils
+try:
+    from . import config
+    from . import db
+    from . import utils
+except ImportError:  # pragma: no cover - fallback for script execution
+    import config  # type: ignore
+    import db  # type: ignore
+    import utils  # type: ignore
 
 from logging_setup import get_logger
 from webwork.dedup import (

--- a/moderator.py
+++ b/moderator.py
@@ -10,8 +10,12 @@ import sqlite3
 import time
 from typing import Any, Dict, Optional
 
-import config
-import publisher
+try:
+    from . import config
+    from . import publisher
+except ImportError:  # pragma: no cover - fallback for script execution
+    import config  # type: ignore
+    import publisher  # type: ignore
 
 from logging_setup import get_logger
 

--- a/publisher.py
+++ b/publisher.py
@@ -17,11 +17,18 @@ from urllib.parse import urlparse
 
 import requests
 
-import config
-import dedup
-import moderation
-import rewrite
-import seen_store
+try:
+    from . import config
+    from . import dedup
+    from . import moderation
+    from . import rewrite
+    from . import seen_store
+except ImportError:  # pragma: no cover - fallback for script execution
+    import config  # type: ignore
+    import dedup  # type: ignore
+    import moderation  # type: ignore
+    import rewrite  # type: ignore
+    import seen_store  # type: ignore
 from formatting import clean_html_tags, html_escape, truncate_by_chars
 from logging_setup import audit, get_logger, mask_secrets
 from webwork.utils.formatting import chunk_text, safe_format, TG_TEXT_LIMIT


### PR DESCRIPTION
## Summary
- update bot, moderation, publisher, and dedup modules to prefer package-relative imports
- fall back to absolute imports only when running modules as standalone scripts
- ensures tests can reliably monkeypatch shared modules without duplicate imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de05c79b4c83338e434d74062fc2b8