### PR TITLE
Improve Windows launch compatibility

### DIFF
--- a/autostart.py
+++ b/autostart.py
@@ -1168,8 +1168,26 @@ class App(tk.Tk):
     def _start_with_args(self, extra_args: list[str]) -> bool:
         if not self._ensure_repo():
             return False
-        if sys.platform == "win32" and (self.repo_dir / "start.bat").exists():
-            cmd_list = [str(self.repo_dir / "start.bat")]
+        if sys.platform == "win32":
+            cmd_list: list[str] = []
+            windows_candidates: list[tuple[str, list[str]]] = [
+                ("Start-WebWork.bat", ["cmd", "/c", "call"]),
+                ("start.bat", ["cmd", "/c", "call"]),
+                ("bootstrap.ps1", [
+                    "powershell",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                ]),
+            ]
+            for name, prefix in windows_candidates:
+                path = self.repo_dir / name
+                if path.exists():
+                    cmd_list = [*prefix, str(path)]
+                    break
+            if not cmd_list:
+                cmd_list = [sys.executable, "main.py"]
         elif sys.platform != "win32" and (self.repo_dir / "start.sh").exists():
             cmd_list = ["bash", str(self.repo_dir / "start.sh")]
         else:

--- a/start.bat
+++ b/start.bat
@@ -3,7 +3,61 @@ setlocal
 chcp 65001 >nul
 set "PYTHONUTF8=1"
 set "PYTHONIOENCODING=utf-8"
-if not exist ".venv\Scripts\python.exe" py -3 -m venv .venv
-call ".venv\Scripts\python.exe" -X utf8 -m pip install -r requirements.txt --no-cache-dir
-call ".venv\Scripts\python.exe" -X utf8 main.py %*
-endlocal
+
+rem Ensure we run from the repository root
+pushd "%~dp0" >nul 2>&1
+
+set "PY_CMD="
+set "PY_ARGS="
+where /Q py.exe 2>nul
+if not errorlevel 1 (
+    set "PY_CMD=py"
+    set "PY_ARGS=-3"
+    goto :after_python_detect
+)
+for %%C in (python3 python) do (
+    where /Q %%C.exe 2>nul
+    if not errorlevel 1 (
+        set "PY_CMD=%%C"
+        set "PY_ARGS="
+        goto :after_python_detect
+    )
+)
+echo [ERROR] Python 3.x is not available in PATH. Install it from https://www.python.org/downloads/ and try again.
+set "ERR=9009"
+popd >nul 2>&1
+endlocal & exit /b %ERR%
+
+:after_python_detect
+set "VENV_DIR=%CD%\.venv"
+set "VENV_PY=%VENV_DIR%\Scripts\python.exe"
+if not exist "%VENV_PY%" (
+    echo [INFO] Creating virtual environment in "%VENV_DIR%"
+    call %PY_CMD% %PY_ARGS% -m venv "%VENV_DIR%"
+    if errorlevel 1 (
+        echo [ERROR] Failed to create virtual environment.
+        set "ERR=%ERRORLEVEL%"
+        popd >nul 2>&1
+        endlocal & exit /b %ERR%
+    )
+)
+
+if exist requirements.txt (
+    echo [INFO] Installing dependencies from requirements.txt
+    call "%VENV_PY%" -m pip install -r requirements.txt --no-cache-dir
+    if errorlevel 1 (
+        echo [ERROR] Dependency installation failed.
+        set "ERR=%ERRORLEVEL%"
+        popd >nul 2>&1
+        endlocal & exit /b %ERR%
+    )
+) else (
+    echo [WARN] requirements.txt not found, skipping dependency installation.
+)
+
+echo [INFO] Starting WebWork...
+call "%VENV_PY%" -X utf8 main.py %*
+set "EXIT_CODE=%ERRORLEVEL%"
+
+popd >nul 2>&1
+endlocal & exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary
- update the autostart GUI to prefer Windows launcher scripts and execute .bat/.ps1 wrappers correctly
- harden the Windows start.bat so it locates Python reliably, sets up the venv in-place, and surfaces clearer errors when dependencies are missing

## Testing
- python -m compileall autostart.py

------
https://chatgpt.com/codex/tasks/task_e_68deb9cfc7b48333aa71753847aec6ba