### PR TITLE
Fix PowerShell bootstrap parameter handling

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,10 +1,10 @@
 #requires -Version 5.1
-$ErrorActionPreference = "Stop"
-
 param(
   [Parameter(ValueFromRemainingArguments=$true)]
   [string[]]$AppArgs
 )
+
+$ErrorActionPreference = "Stop"
 
 # 0) Work in script directory
 Set-Location -LiteralPath (Split-Path -Parent $MyInvocation.MyCommand.Path)


### PR DESCRIPTION
## Summary
- ensure the param block in bootstrap.ps1 is declared before any executable statements so that arguments like `--loop` can be parsed correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68debcc8b98c833390b907a9ff9ed4db