### PR TITLE
Fix Windows bootstrap to install dependencies with pip

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -44,6 +44,12 @@ if (-not (Get-Command uv -ErrorAction SilentlyContinue)) { throw "uv is not avai
 # 3) Create venv if missing
 if (-not (Test-Path ".venv")) { uv venv | Out-Null }
 
+$venvPython = Join-Path ".venv" "Scripts/python.exe"
+if (-not (Test-Path $venvPython)) {
+  $venvPython = Join-Path ".venv" "bin/python"
+}
+if (-not (Test-Path $venvPython)) { throw "Python executable not found in virtual environment" }
+
 # 4) Dependencies (wheel-first) + minimal guarantees
 if (Test-Path "requirements.txt") {
   $req = Get-Content "requirements.txt" -Raw
@@ -65,10 +71,16 @@ if (Test-Path "requirements.txt") {
     }
   }
 
-  uv sync --no-dev
+  & $venvPython -m pip install --upgrade pip
+  & $venvPython -m pip install -r "requirements.txt"
 } else {
-  uv pip install python-dotenv platformdirs
+  & $venvPython -m pip install --upgrade pip
+  & $venvPython -m pip install python-dotenv>=1.0.0 platformdirs>=4.0.0
 }
 
 # 5) Run app and forward user args
-if ($AppArgs.Count -gt 0) { uv run python .\main.py @AppArgs } else { uv run python .\main.py }
+if ($AppArgs.Count -gt 0) {
+  & $venvPython "./main.py" @AppArgs
+} else {
+  & $venvPython "./main.py"
+}


### PR DESCRIPTION
## Summary
- update the Windows bootstrap script to resolve the virtualenv Python executable
- install dependencies with the virtualenv's pip instead of relying on `uv sync`
- run the application using the virtualenv Python so the launcher no longer requires a pyproject

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debee65c288333ac8056548220b614