### PR TITLE
Improve virtualenv pip recovery

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -44,6 +44,11 @@ if not exist "%VENV_PY%" (
 
 call "%VENV_PY%" -m pip --version >nul 2>&1
 if errorlevel 1 (
+    call %PY_CMD% %PY_ARGS% -m venv --upgrade-deps "%VENV_DIR%"
+)
+
+call "%VENV_PY%" -m pip --version >nul 2>&1
+if errorlevel 1 (
     call "%VENV_PY%" -m ensurepip --upgrade >nul 2>&1
 )
 

--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,12 @@ ensure_pip() {
     return 0
   fi
 
+  python3 -m venv --upgrade-deps .venv >/dev/null 2>&1 || true
+
+  if python -m pip --version >/dev/null 2>&1; then
+    return 0
+  fi
+
   python -m ensurepip --upgrade >/dev/null 2>&1 || true
 
   if python -m pip --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- try upgrading the virtual environment dependencies when pip is missing in the Windows start script
- add the same fallback to the Unix start script so both paths can recover pip before using ensurepip

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df5c95c79883339dedfbeec2de53da