### PR TITLE
Skip Telegram fetch when Telethon credentials missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,19 +127,30 @@ def run_once(
         )
         items_iter = []
     else:
-        from telegram_fetcher import fetch_from_telegram
-
-        items_iter = list(
-            fetch_from_telegram(
-                getattr(config, "TELEGRAM_MODE", "mtproto"),
-                getattr(config, "TELEGRAM_LINKS_FILE", "telegram_links.txt"),
-                getattr(config, "TELEGRAM_FETCH_LIMIT", 30),
+        mode = getattr(config, "TELEGRAM_MODE", "mtproto")
+        if mode == "mtproto" and (
+            int(getattr(config, "TELETHON_API_ID", 0) or 0) <= 0
+            or not getattr(config, "TELETHON_API_HASH", "")
+        ):
+            logger.warning(
+                "TELEGRAM_MODE=mtproto, но TELETHON_API_ID/TELETHON_API_HASH не заданы. "
+                "Пропускаем загрузку из Telegram."
             )
-        )
-        logger.info(
-            "Загрузка из Telegram: получено %d элементов (парсинг сайтов отключён)",
-            len(items_iter),
-        )
+            items_iter = []
+        else:
+            from telegram_fetcher import fetch_from_telegram
+
+            items_iter = list(
+                fetch_from_telegram(
+                    mode,
+                    getattr(config, "TELEGRAM_LINKS_FILE", "telegram_links.txt"),
+                    getattr(config, "TELEGRAM_FETCH_LIMIT", 30),
+                )
+            )
+            logger.info(
+                "Загрузка из Telegram: получено %d элементов (парсинг сайтов отключён)",
+                len(items_iter),
+            )
 
     seen_urls: set = set()
     seen_title_hashes: set = set()

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -1,0 +1,43 @@
+import logging
+import sqlite3
+import sys
+import types
+
+import main
+import config
+
+
+def test_run_once_skips_mtproto_when_credentials_missing(monkeypatch, caplog):
+    conn = sqlite3.connect(":memory:")
+
+    monkeypatch.setattr(config, "RAW_STREAM_ENABLED", False)
+    monkeypatch.setattr(config, "TELEGRAM_AUTO_FETCH", True)
+    monkeypatch.setattr(config, "TELEGRAM_MODE", "mtproto")
+    monkeypatch.setattr(config, "TELEGRAM_LINKS_FILE", "dummy_links.txt")
+    monkeypatch.setattr(config, "TELEGRAM_FETCH_LIMIT", 5)
+    monkeypatch.setattr(config, "TELETHON_API_ID", 0)
+    monkeypatch.setattr(config, "TELETHON_API_HASH", "")
+    monkeypatch.setattr(config, "ITEM_RETENTION_DAYS", 0)
+    monkeypatch.setattr(config, "DEDUP_RETENTION_DAYS", 0)
+    monkeypatch.setattr(config, "SOURCES_BY_NAME", {})
+    monkeypatch.setattr(config, "SOURCES_BY_DOMAIN_ALL", {})
+
+    fake_fetch_called = False
+
+    def fake_fetch(*args, **kwargs):  # pragma: no cover - defensive
+        nonlocal fake_fetch_called
+        fake_fetch_called = True
+        raise AssertionError("fetch_from_telegram should not be called")
+
+    fake_module = types.SimpleNamespace(fetch_from_telegram=fake_fetch)
+    monkeypatch.setitem(sys.modules, "telegram_fetcher", fake_module)
+
+    caplog.set_level(logging.WARNING)
+
+    result = main.run_once(conn, raw_mode="skip")
+
+    assert result == (0, 0, 0, 0, 0, 0, 0, 0)
+    assert not fake_fetch_called
+    assert any(
+        "TELEGRAM_MODE=mtproto" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- avoid calling the Telegram MTProto fetcher when credentials are absent so the loop keeps running
- log a warning and add a regression test covering the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2afe41f5c83339de9d299673777ac