### PR TITLE
Add package entrypoint for main loop

### DIFF
--- a/tests/test_webwork_entrypoint.py
+++ b/tests/test_webwork_entrypoint.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_webwork_main_delegates_to_legacy_main(monkeypatch):
+    import main as legacy_main
+
+    calls: list[int] = []
+
+    def fake_main() -> int:
+        calls.append(1)
+        return 42
+
+    monkeypatch.setattr(legacy_main, "main", fake_main)
+
+    module = importlib.import_module("webwork.main")
+    result = module.main()
+
+    assert result == 42
+    assert calls == [1]
+
+
+def test_webwork_main_injects_repo_root(monkeypatch):
+    import main as legacy_main
+
+    repo_root = str(Path(__file__).resolve().parents[1])
+    monkeypatch.setattr(legacy_main, "main", lambda: 0)
+    # Remove repo root from sys.path copy so that the entrypoint has to add it
+    filtered_path = [p for p in sys.path if p != repo_root]
+    monkeypatch.setattr(sys, "path", filtered_path, raising=False)
+
+    module = importlib.import_module("webwork.main")
+    module.main()
+
+    assert repo_root in sys.path

--- a/webwork/main.py
+++ b/webwork/main.py
@@ -1,0 +1,51 @@
+"""Compatibility entrypoint for ``python -m webwork.main``.
+
+This module mirrors the behaviour of running ``python main.py`` from the
+repository root.  It ensures that the project root is present on
+``sys.path`` and then delegates execution to :func:`main.main` from the
+legacy flat-layout script.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Sequence
+
+__all__ = ["main"]
+
+
+def _ensure_repo_root() -> None:
+    """Add the repository root to ``sys.path`` if it is missing."""
+
+    repo_root = Path(__file__).resolve().parent.parent
+    repo_str = str(repo_root)
+    if repo_str not in sys.path:
+        sys.path.insert(0, repo_str)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Execute the legacy ``main`` module and return its exit code.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments to override ``sys.argv``
+        for the delegated call.  When ``None`` (the default) the current
+        ``sys.argv`` is preserved, matching the behaviour of ``python -m``.
+    """
+
+    _ensure_repo_root()
+    if argv is not None:
+        sys.argv = [sys.argv[0], *argv]
+    main_module = importlib.import_module("main")
+    entry = getattr(main_module, "main", None)
+    if entry is None:
+        raise RuntimeError("main module does not define main()")
+    result = entry()
+    return int(result) if result is not None else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `webwork/main.py` shim so `python -m webwork.main` behaves the same as running the legacy flat-layout script
- ensure the shim prepends the repository root to `sys.path` before delegating to `main.main`
- cover the new entrypoint with tests that verify delegation and path adjustment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3acc00e4883338b0fd1c1ba1ca076