### PR TITLE
Add loop iteration logging and BaseException handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -567,17 +567,27 @@ def main() -> int:
             )
         return 0
 
-    logger.info("Старт бесконечного цикла. Пауза: %d сек.", config.LOOP_DELAY_SECS)
+    logger.info(
+        "Старт бесконечного цикла обработки (LOOP_DELAY_SECS=%d)",
+        config.LOOP_DELAY_SECS,
+    )
     while True:
+        logger.info("===> Итерация старта")
         try:
             run_once(conn, raw_mode=raw_mode)
+            logger.info("===> Итерация завершена, sleep")
             time.sleep(config.LOOP_DELAY_SECS)
         except KeyboardInterrupt:
             logger.warning("Остановка по Ctrl+C")
             break
         except Exception as ex:
-            logger.exception("Неожиданная ошибка цикла: %s", ex)
+            logger.exception("Ошибка на итерации цикла: %s", ex)
             time.sleep(15)
+        except BaseException as ex:
+            logger.exception("FATAL BaseException: %s", ex)
+            time.sleep(15)
+
+    logger.info("Вышли из while True")
 
     stop_event.set()
     if updates_thread is not None:


### PR DESCRIPTION
## Summary
- add detailed logging at the start and end of each loop iteration
- log unexpected exceptions and fatal base exceptions with delays to keep the loop alive
- log when the loop exits for easier diagnostics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4b60305e48333b58f3d44026e11b6