### PR TITLE
Add watchdog around fetch_from_telegram execution

### DIFF
--- a/tests/test_telegram_fetcher_timeout.py
+++ b/tests/test_telegram_fetcher_timeout.py
@@ -1,0 +1,42 @@
+import pathlib
+import sys
+import threading
+import time
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import telegram_fetcher
+
+
+def test_fetch_from_telegram_timeout_returns_control(monkeypatch):
+    call_started = threading.Event()
+    release_worker = threading.Event()
+
+    def fake_fetch_sync(mode, links_file, limit, opts):
+        call_started.set()
+        release_worker.wait(timeout=30)
+        return []
+
+    monkeypatch.setattr(telegram_fetcher, "_fetch_from_telegram_sync", fake_fetch_sync)
+
+    start = time.monotonic()
+    elapsed = None
+    try:
+        with pytest.raises(telegram_fetcher.TelegramFetchTimeoutError):
+            telegram_fetcher.fetch_from_telegram(
+                "mtproto",
+                "dummy_links.txt",
+                5,
+                options=telegram_fetcher.FetchOptions(timeout_seconds=1.0),
+                timeout=1.0,
+            )
+    finally:
+        elapsed = time.monotonic() - start
+        release_worker.set()
+    assert call_started.wait(timeout=1.0)
+    assert elapsed is not None and elapsed < 5.0
+


### PR DESCRIPTION
## Summary
- replace the ThreadPoolExecutor wrapper with a daemon worker thread and watchdog logging so `fetch_from_telegram` always returns control on timeout
- add detailed lifecycle logging around worker execution and re-raise captured exceptions with original tracebacks
- cover the timeout behaviour with a regression test that simulates a stuck fetcher

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4cf75271c8333b92e92dadc5bb2fe