### PR TITLE
Fail fast when Telethon session is missing

### DIFF
--- a/telegram_fetcher.py
+++ b/telegram_fetcher.py
@@ -248,6 +248,20 @@ async def _fetch_mtproto_async(
         flood_sleep_threshold=flood_threshold,
     )
     log.debug("fetch_mtproto_async: Telethon client created session=%s", session)
+    session_obj = getattr(client, "session", None)
+    session_filename = getattr(session_obj, "filename", None)
+    if isinstance(session_filename, str) and session_filename.strip():
+        raw_path = Path(session_filename).expanduser()
+        if not raw_path.is_absolute():
+            raw_path = Path.cwd() / raw_path
+        if not raw_path.exists():
+            message = (
+                "Не найден файл сессии Telethon: "
+                f"{raw_path}. Завершите интерактивный вход один раз или "
+                "передайте путь к готовому .session через TELETHON_SESSION_NAME."
+            )
+            log.error("fetch_mtproto_async: %s", message)
+            raise RuntimeError(message)
     concurrency = options.fetch_workers if options else 5
     bucket = get_global_bucket((options.rate if options else 25.0) or 25.0)
     fetch_timeout = None

--- a/tests/test_telegram_fetcher_session.py
+++ b/tests/test_telegram_fetcher_session.py
@@ -1,0 +1,40 @@
+import pathlib
+import sys
+import types
+
+import asyncio
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import telegram_fetcher
+
+
+def test_fetch_mtproto_async_requires_session_file(monkeypatch, tmp_path):
+    missing_session = tmp_path / "missing.session"
+
+    class DummyClient:
+        def __init__(self, filename: str):
+            self.session = types.SimpleNamespace(filename=filename)
+
+        async def __aenter__(self):  # pragma: no cover - should not be called
+            raise AssertionError("client should not be entered when session missing")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(telegram_fetcher, "get_mtproto_client", lambda *a, **k: DummyClient(str(missing_session)))
+    monkeypatch.setattr(telegram_fetcher.config, "TELETHON_API_ID", 12345)
+    monkeypatch.setattr(telegram_fetcher.config, "TELETHON_API_HASH", "hash")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(
+            telegram_fetcher._fetch_mtproto_async(
+                ["example"], 5, options=telegram_fetcher.FetchOptions()
+            )
+        )
+
+    assert str(missing_session) in str(exc_info.value)


### PR DESCRIPTION
## Summary
- raise an explicit error if the Telethon session file is absent so automated runs do not block waiting for interactive input
- cover the missing-session scenario with a regression test for the Telegram fetcher

## Testing
- pytest tests/test_telegram_fetcher_timeout.py tests/test_telegram_fetcher_session.py

------
https://chatgpt.com/codex/tasks/task_e_68e4d2216d5c8333bfe84f294e2285df